### PR TITLE
pusher 모듈 및 이메일 전송 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     implementation "io.springfox:springfox-boot-starter:3.0.0"
     implementation "io.springfox:springfox-swagger-ui:3.0.0"

--- a/sql/titi.sql
+++ b/sql/titi.sql
@@ -57,3 +57,28 @@ CREATE TABLE IF NOT EXISTS oauth2_infos
     CONSTRAINT fk_oauth2_infos_member_id FOREIGN KEY (member_id) REFERENCES members(id),
     UNIQUE INDEX uix_oauth2_infos_provider_id (provider, provider_id)
 ) COMMENT 'OAuth2 정보';
+
+CREATE TABLE IF NOT EXISTS notifications
+(
+    uid                    BIGINT NOT NULL,
+    notification_category  ENUM ('INFORMATION', 'NOTICE', 'MARKETING', 'AUTHENTICATION') NOT NULL COMMENT '알림 종류',
+    notification_type      ENUM ('EMAIL') NOT NULL COMMENT '알림 유형',
+    notification_status    ENUM ('COMPLETED', 'FAILED') NOT NULL COMMENT '알림 상태',
+    target_type            ENUM ('EMAIL') NOT NULL COMMENT '수신 유형',
+    target_value           VARCHAR(255) NOT NULL COMMENT '수신자 정보',
+    service_name           ENUM ('AUTH')  NOT NULL COMMENT '서비스명',
+    service_request_id     VARCHAR(50) NOT NULL COMMENT '서비스 요청 ID',
+    notified_at            DATETIME(6) NULL COMMENT '발송 일시',
+    created_at             DATETIME(6) NOT NULL COMMENT '생성 일시',
+    updated_at             DATETIME(6) NOT NULL COMMENT '수정 일시',
+    PRIMARY KEY (uid)
+) COMMENT '알림';
+
+CREATE TABLE IF NOT EXISTS notification_histories
+(
+    uid                 BIGINT NOT NULL,
+    notification_id     BIGINT NOT NULL COMMENT '알림 PK',
+    notification_status ENUM ('REQUESTED', 'COMPLETED', 'FAILED') NOT NULL COMMENT '알림 상태',
+    created_at          datetime(6) NOT NULL COMMENT '생성 일시',
+    PRIMARY KEY (uid)
+) COMMENT '알림 이력';

--- a/src/main/java/com/titi/common/util/RandomGenerator.java
+++ b/src/main/java/com/titi/common/util/RandomGenerator.java
@@ -1,0 +1,74 @@
+package com.titi.common.util;
+
+import java.security.SecureRandom;
+import java.util.HashSet;
+import java.util.Set;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RandomGenerator {
+
+	private static final String LOWERCASE_CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
+	private static final String UPPERCASE_CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+	private static final String NUMBERS = "0123456789";
+
+	/**
+	 * Generates a random string based on specified criteria.
+	 *
+	 * @param includeNumber      		Whether to include numeric characters in the generated string.
+	 * @param includeLowercase   		Whether to include lowercase alphabetic characters in the generated string.
+	 * @param includeUppercase   		Whether to include uppercase alphabetic characters in the generated string.
+	 * @param length             		The length of the generated string.
+	 * @param allowsDuplication  		Whether duplication of characters is allowed in the generated string.
+	 * @return                   		The randomly generated string based on the provided criteria.
+	 * @throws IllegalArgumentException If none of the character sets (number, lowercase, uppercase) is included.
+	 */
+	public static String generate(boolean includeNumber, boolean includeLowercase, boolean includeUppercase, int length, boolean allowsDuplication) {
+		validateParameters(includeNumber, includeLowercase, includeUppercase);
+		return generateRandom(length, allowsDuplication, generateCharacters(includeNumber, includeLowercase, includeUppercase));
+	}
+
+	private static String generateRandom(int length, boolean allowsDuplication, StringBuilder characters) {
+		final SecureRandom random = new SecureRandom();
+		final StringBuilder result = new StringBuilder();
+
+		if (allowsDuplication) {
+			for (int i = 0; i < length; i++) {
+				result.append(characters.charAt(random.nextInt(characters.length())));
+			}
+		} else {
+			final Set<Character> uniqueCharacters = new HashSet<>();
+			while (uniqueCharacters.size() < length) {
+				uniqueCharacters.add(characters.charAt(random.nextInt(characters.length())));
+			}
+			for (char c : uniqueCharacters) {
+				result.append(c);
+			}
+		}
+
+		return result.toString();
+	}
+
+	private static void validateParameters(boolean includeNumber, boolean includeLowercase, boolean includeUppercase) {
+		if (!includeNumber && !includeLowercase && !includeUppercase) {
+			throw new IllegalArgumentException("At least one character set (number, lowercase, uppercase) must be included.");
+		}
+	}
+
+	private static StringBuilder generateCharacters(boolean includeNumber, boolean includeLowercase, boolean includeUppercase) {
+		final StringBuilder characters = new StringBuilder();
+		if (includeNumber) {
+			characters.append(NUMBERS);
+		}
+		if (includeLowercase) {
+			characters.append(LOWERCASE_CHARACTERS);
+		}
+		if (includeUppercase) {
+			characters.append(UPPERCASE_CHARACTERS);
+		}
+		return characters;
+	}
+
+}

--- a/src/main/java/com/titi/common/util/UidUtils.java
+++ b/src/main/java/com/titi/common/util/UidUtils.java
@@ -1,0 +1,121 @@
+package com.titi.common.util;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.concurrent.ThreadLocalRandom;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class UidUtils {
+
+	/**
+	 * Unit for the UNIX timestamp part (milliseconds since January 1, 1970) in the 19-digit Uid format.
+	 */
+	private static final long UID_TIMESTAMP_UNIT = 1_000_000;
+	/**
+	 * Maximum value for the random number part (6-digit) in the 19-digit Uid format.
+	 */
+	private static final int UID_RANDOM_MAX = 999_999;
+
+	/**
+	 * Generates a 19-digit Uid (Unique Identifier) by combining a 13-digit UNIX timestamp
+	 * with a 6-digit random number.
+	 * <p>
+	 * The UNIX timestamp represents the number of milliseconds elapsed since January 1, 1970 (UTC).
+	 * The random number adds variability to ensure uniqueness.
+	 *
+	 * @return A unique 19-digit Uid.
+	 */
+	public static long generateUid() {
+		return generateUid(LocalDateTime.now(ZoneOffset.UTC));
+	}
+
+	/**
+	 * Generates a 19-digit Uid based on the provided LocalDateTime by combining
+	 * a 13-digit UNIX timestamp with a 6-digit random number.
+	 * <p>
+	 * The UNIX timestamp represents the number of milliseconds elapsed since January 1, 1970 (UTC).
+	 * The random number adds variability to ensure uniqueness.
+	 *
+	 * @param dateTime The LocalDateTime to use for generating the Uid.
+	 * @return A unique 19-digit Uid.
+	 */
+	public static long generateUid(LocalDateTime dateTime) {
+		final String timestampArea = String.valueOf(dateTime.atZone(ZoneOffset.UTC).toInstant().toEpochMilli());
+		final String randomArea = get6DigitRandomNumberString();
+		return Long.parseLong(timestampArea + randomArea);
+	}
+
+	/**
+	 * Returns the minimum Uid (Unique Identifier) value that corresponds to the provided LocalDateTime.
+	 * The minimum Uid is calculated by multiplying the UNIX timestamp (milliseconds since January 1, 1970) by 1,000,000.
+	 *
+	 * @param datetime The LocalDateTime for which the minimum Uid is calculated.
+	 * @return The minimum Uid.
+	 */
+	public static long getMinUidByLocalDateTime(LocalDateTime datetime) {
+		return getMinUidByUnixMilli(datetime.atZone(ZoneOffset.UTC).toInstant().toEpochMilli());
+	}
+
+	/**
+	 * Returns the maximum Uid (Unique Identifier) value that corresponds to the provided LocalDateTime.
+	 * The maximum Uid is calculated by adding 999,999 to the minimum Uid.
+	 *
+	 * @param datetime The LocalDateTime for which the maximum Uid is calculated.
+	 * @return The maximum Uid.
+	 */
+	public static long getMaxUidByLocalDateTime(LocalDateTime datetime) {
+		return getMaxUidByUnixMilli(datetime.atZone(ZoneOffset.UTC).toInstant().toEpochMilli());
+	}
+
+	/**
+	 * Returns the minimum Uid value based on the provided UNIX timestamp (milliseconds since January 1, 1970).
+	 * The minimum Uid is calculated by multiplying the UNIX timestamp by 1,000,000.
+	 *
+	 * @param unixTime The UNIX timestamp in milliseconds.
+	 * @return The minimum Uid.
+	 */
+	public static long getMinUidByUnixMilli(long unixTime) {
+		return unixTime * UID_TIMESTAMP_UNIT;
+	}
+
+	/**
+	 * Returns the maximum Uid value based on the provided UNIX timestamp (milliseconds since January 1, 1970).
+	 * The maximum Uid is calculated by adding 999,999 to the minimum Uid.
+	 *
+	 * @param unixTime The UNIX timestamp in milliseconds.
+	 * @return The maximum Uid.
+	 */
+	public static long getMaxUidByUnixMilli(long unixTime) {
+		return getMinUidByUnixMilli(unixTime) + UID_RANDOM_MAX;
+	}
+
+	/**
+	 * Extracts the UNIX timestamp (milliseconds since January 1, 1970) from the given Uid.
+	 *
+	 * @param uid The Uid from which to extract the UNIX timestamp.
+	 * @return The UNIX timestamp.
+	 */
+	public static long getUnixTimestampFromUid(long uid) {
+		return uid / UID_TIMESTAMP_UNIT;
+	}
+
+	/**
+	 * Converts the given Uid to a LocalDateTime representation in the UTC time zone.
+	 *
+	 * @param uid The Uid for which to retrieve the LocalDateTime representation.
+	 * @return The LocalDateTime representation of the Uid.
+	 */
+	public static LocalDateTime getLocalDatetimeFromUid(long uid) {
+		return LocalDateTime.ofInstant(Instant.ofEpochMilli(getUnixTimestampFromUid(uid)), ZoneId.of("UTC"));
+	}
+
+	private static String get6DigitRandomNumberString() {
+		return String.format("%06d", ThreadLocalRandom.current().nextInt(UID_RANDOM_MAX));
+	}
+
+}

--- a/src/main/java/com/titi/config/CryptoConfig.java
+++ b/src/main/java/com/titi/config/CryptoConfig.java
@@ -1,0 +1,19 @@
+package com.titi.config;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.titi.crypto.util.CryptoUtils;
+
+@Configuration
+public class CryptoConfig {
+
+	@Bean
+	public CryptoUtils cryptoUtils(@Value(value = "${crypto.secret-key}") String secretKey) {
+		return new CryptoUtils(secretKey.getBytes(StandardCharsets.UTF_8));
+	}
+
+}

--- a/src/main/java/com/titi/crypto/util/CryptoUtils.java
+++ b/src/main/java/com/titi/crypto/util/CryptoUtils.java
@@ -1,0 +1,21 @@
+package com.titi.crypto.util;
+
+import com.titi.crypto.constant.AESCipherModes;
+
+public final class CryptoUtils {
+
+	private final byte[] secretKey;
+
+	public CryptoUtils(byte[] secretKey) {
+		this.secretKey = secretKey;
+	}
+
+	public byte[] encrypt(byte[] data) {
+		return AESUtils.encrypt(secretKey, data, AESCipherModes.GCM_NO_PADDING);
+	}
+
+	public byte[] decrypt(byte[] data) {
+		return AESUtils.decrypt(secretKey, data, AESCipherModes.GCM_NO_PADDING);
+	}
+
+}

--- a/src/main/java/com/titi/pusher/adapter/in/internal/InternalSendMailGateway.java
+++ b/src/main/java/com/titi/pusher/adapter/in/internal/InternalSendMailGateway.java
@@ -1,0 +1,55 @@
+package com.titi.pusher.adapter.in.internal;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+import com.titi.pusher.application.port.in.email.SendMailUseCase;
+import com.titi.pusher.domain.notification.Notification;
+
+@Component
+@RequiredArgsConstructor
+public class InternalSendMailGateway {
+
+	private final SendMailUseCase sendMailUseCase;
+	/**
+	 * The official email account of the Timer TiTi service.
+	 */
+	@Value("${spring.mail.username}")
+	private String from;
+
+	public SendSimpleMessageResponse sendSimpleMessage(SendSimpleMessageRequest request) {
+		final Notification notification = this.sendMailUseCase.invoke(
+			SendMailUseCase.Command.ToSimpleMessage.builder()
+				.from(this.from)
+				.to(request.to())
+				.subject(request.subject())
+				.text(request.text())
+				.build()
+		);
+		return SendSimpleMessageResponse.builder()
+			.messageId(notification.notificationId().toString())
+			.messageStatus(notification.notificationStatus().name())
+			.build();
+	}
+
+	@Builder
+	public record SendSimpleMessageRequest(
+		String to,
+		String subject,
+		String text
+	) {
+
+	}
+
+	@Builder
+	public record SendSimpleMessageResponse(
+		String messageId,
+		String messageStatus
+	) {
+
+	}
+
+}

--- a/src/main/java/com/titi/pusher/adapter/out/persistence/NotificationPortAdapter.java
+++ b/src/main/java/com/titi/pusher/adapter/out/persistence/NotificationPortAdapter.java
@@ -1,0 +1,40 @@
+package com.titi.pusher.adapter.out.persistence;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+import com.titi.pusher.adapter.out.persistence.mapper.NotificationMapper;
+import com.titi.pusher.application.port.out.persistence.notification.CreateNotificationPort;
+import com.titi.pusher.application.port.out.persistence.notification.UpdateNotificationPort;
+import com.titi.pusher.data.jpa.entity.NotificationEntity;
+import com.titi.pusher.data.jpa.entity.NotificationHistoryEntity;
+import com.titi.pusher.data.jpa.repository.NotificationEntityRepository;
+import com.titi.pusher.data.jpa.repository.NotificationHistoryEntityRepository;
+import com.titi.pusher.domain.notification.Notification;
+
+@Component
+@RequiredArgsConstructor
+class NotificationPortAdapter implements CreateNotificationPort, UpdateNotificationPort {
+
+	private final NotificationMapper notificationMapper;
+	private final NotificationEntityRepository notificationEntityRepository;
+	private final NotificationHistoryEntityRepository notificationHistoryEntityRepository;
+
+	@Override
+	public void create(Notification notification) {
+		final NotificationEntity entity = this.notificationMapper.toEntity(notification);
+		this.notificationEntityRepository.save(entity);
+		final NotificationHistoryEntity historyEntity = this.notificationMapper.toHistoryEntity(notification);
+		this.notificationHistoryEntityRepository.save(historyEntity);
+	}
+
+	@Override
+	public void update(Notification notification) {
+		final NotificationEntity entity = this.notificationMapper.toEntity(notification);
+		this.notificationEntityRepository.save(entity);
+		final NotificationHistoryEntity historyEntity = this.notificationMapper.toHistoryEntity(notification);
+		this.notificationHistoryEntityRepository.save(historyEntity);
+	}
+
+}

--- a/src/main/java/com/titi/pusher/adapter/out/persistence/mapper/NotificationMapper.java
+++ b/src/main/java/com/titi/pusher/adapter/out/persistence/mapper/NotificationMapper.java
@@ -1,0 +1,48 @@
+package com.titi.pusher.adapter.out.persistence.mapper;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+import com.titi.common.util.UidUtils;
+import com.titi.crypto.util.CryptoUtils;
+import com.titi.pusher.data.jpa.entity.NotificationEntity;
+import com.titi.pusher.data.jpa.entity.NotificationHistoryEntity;
+import com.titi.pusher.domain.notification.Notification;
+import com.titi.pusher.domain.notification.TargetInfo;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationMapper {
+
+	private final CryptoUtils cryptoUtils;
+
+	public NotificationEntity toEntity(Notification notification) {
+		return NotificationEntity.builder()
+			.uid(notification.notificationId())
+			.notificationCategory(notification.notificationCategory())
+			.notificationType(notification.notificationType())
+			.notificationStatus(notification.notificationStatus())
+			.targetType(notification.targetInfo().getType())
+			.targetValue(getTargetValue(notification.targetInfo()))
+			.serviceName(notification.serviceInfo().name())
+			.serviceRequestId(notification.serviceInfo().requestId())
+			.notifiedAt(notification.notifiedAt())
+			.build();
+	}
+
+	public NotificationHistoryEntity toHistoryEntity(Notification notification) {
+		return NotificationHistoryEntity.builder()
+			.uid(UidUtils.generateUid())
+			.notificationId(notification.notificationId())
+			.notificationStatus(notification.notificationStatus())
+			.build();
+	}
+
+	private String getTargetValue(TargetInfo targetInfo) {
+		return switch (targetInfo) {
+			case TargetInfo.EmailTargetInfo emailTargetInfo -> new String(cryptoUtils.encrypt(emailTargetInfo.email().getBytes()));
+		};
+	}
+
+}

--- a/src/main/java/com/titi/pusher/adapter/out/smtp/SendMailPortAdapter.java
+++ b/src/main/java/com/titi/pusher/adapter/out/smtp/SendMailPortAdapter.java
@@ -1,0 +1,41 @@
+package com.titi.pusher.adapter.out.smtp;
+
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.titi.pusher.application.port.out.smtp.SendMailPort;
+import com.titi.pusher.domain.email.SimpleMailMessage;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class SendMailPortAdapter implements SendMailPort {
+
+	private final JavaMailSender javaMailSender;
+
+	@Override
+	public boolean sendSimpleMessage(SimpleMailMessage message) {
+		try {
+			this.javaMailSender.send(this.createSimpleMailMessage(message));
+		} catch (MailSendException e) {
+			log.error("[SendMailPort] Fail to send mail. message: {}", message, e);
+			return false;
+		}
+		log.info("[SendMailPort] Success to send mail. message: {}", message);
+		return true;
+	}
+
+	private org.springframework.mail.SimpleMailMessage createSimpleMailMessage(SimpleMailMessage message) {
+		final org.springframework.mail.SimpleMailMessage simpleMailMessage = new org.springframework.mail.SimpleMailMessage();
+		simpleMailMessage.setFrom(message.from());
+		simpleMailMessage.setTo(message.to());
+		simpleMailMessage.setSubject(message.subject());
+		simpleMailMessage.setText(message.text());
+		return simpleMailMessage;
+	}
+
+}

--- a/src/main/java/com/titi/pusher/application/port/in/email/SendMailUseCase.java
+++ b/src/main/java/com/titi/pusher/application/port/in/email/SendMailUseCase.java
@@ -1,0 +1,30 @@
+package com.titi.pusher.application.port.in.email;
+
+import lombok.Builder;
+
+import com.titi.pusher.domain.notification.Notification;
+import com.titi.pusher.domain.notification.NotificationCategory;
+import com.titi.pusher.domain.notification.ServiceInfo;
+
+public interface SendMailUseCase {
+
+	Notification invoke(Command command);
+
+	sealed interface Command {
+
+		@Builder
+		record ToSimpleMessage(
+			String from,
+			String to,
+			String subject,
+			String text,
+			NotificationCategory notificationCategory,
+			ServiceInfo.ServiceName serviceName,
+			String serviceRequestId
+		) implements Command {
+
+		}
+
+	}
+
+}

--- a/src/main/java/com/titi/pusher/application/port/out/persistence/notification/CreateNotificationPort.java
+++ b/src/main/java/com/titi/pusher/application/port/out/persistence/notification/CreateNotificationPort.java
@@ -1,0 +1,9 @@
+package com.titi.pusher.application.port.out.persistence.notification;
+
+import com.titi.pusher.domain.notification.Notification;
+
+public interface CreateNotificationPort {
+
+	void create(Notification notification);
+
+}

--- a/src/main/java/com/titi/pusher/application/port/out/persistence/notification/UpdateNotificationPort.java
+++ b/src/main/java/com/titi/pusher/application/port/out/persistence/notification/UpdateNotificationPort.java
@@ -1,0 +1,9 @@
+package com.titi.pusher.application.port.out.persistence.notification;
+
+import com.titi.pusher.domain.notification.Notification;
+
+public interface UpdateNotificationPort {
+
+	void update(Notification notification);
+
+}

--- a/src/main/java/com/titi/pusher/application/port/out/smtp/SendMailPort.java
+++ b/src/main/java/com/titi/pusher/application/port/out/smtp/SendMailPort.java
@@ -1,0 +1,9 @@
+package com.titi.pusher.application.port.out.smtp;
+
+import com.titi.pusher.domain.email.SimpleMailMessage;
+
+public interface SendMailPort {
+
+	boolean sendSimpleMessage(SimpleMailMessage message);
+
+}

--- a/src/main/java/com/titi/pusher/application/service/SendMailService.java
+++ b/src/main/java/com/titi/pusher/application/service/SendMailService.java
@@ -1,0 +1,69 @@
+package com.titi.pusher.application.service;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.titi.pusher.application.port.in.email.SendMailUseCase;
+import com.titi.pusher.application.port.out.persistence.notification.CreateNotificationPort;
+import com.titi.pusher.application.port.out.persistence.notification.UpdateNotificationPort;
+import com.titi.pusher.application.port.out.smtp.SendMailPort;
+import com.titi.pusher.domain.email.SimpleMailMessage;
+import com.titi.pusher.domain.notification.Notification;
+import com.titi.pusher.domain.notification.ServiceInfo;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+class SendMailService implements SendMailUseCase {
+
+	private final SendMailPort sendMailPort;
+	private final CreateNotificationPort createNotificationPort;
+	private final UpdateNotificationPort updateNotificationPort;
+
+	@Override
+	@Transactional
+	public Notification invoke(Command command) {
+		return switch (command) {
+			case Command.ToSimpleMessage message -> {
+				final Notification notification = this.createNotification(message);
+				final boolean isSuccessful = this.sendNotification(message);
+				log.info("[SendMailUseCase] {} to send mail. notificationId: {}", isSuccessful ? "Success" : "Fail", notification.notificationId());
+				yield this.finishNotification(notification, isSuccessful);
+			}
+		};
+	}
+
+	private Notification createNotification(Command.ToSimpleMessage message) {
+		Notification notification = Notification.ofEmail(
+			message.notificationCategory(),
+			message.to(),
+			ServiceInfo.builder()
+				.name(message.serviceName())
+				.requestId(message.serviceRequestId())
+				.build()
+		);
+		this.createNotificationPort.create(notification);
+		return notification;
+	}
+
+	private boolean sendNotification(Command.ToSimpleMessage message) {
+		return this.sendMailPort.sendSimpleMessage(
+			SimpleMailMessage.builder()
+				.from(message.from())
+				.to(message.to())
+				.subject(message.subject())
+				.text(message.text())
+				.build()
+		);
+	}
+
+	private Notification finishNotification(Notification notification, boolean isSuccessful) {
+		notification = isSuccessful ? notification.complete() : notification.fail();
+		this.updateNotificationPort.update(notification);
+		return notification;
+	}
+
+}

--- a/src/main/java/com/titi/pusher/data/jpa/entity/NotificationEntity.java
+++ b/src/main/java/com/titi/pusher/data/jpa/entity/NotificationEntity.java
@@ -1,0 +1,62 @@
+package com.titi.pusher.data.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.titi.infrastructure.persistence.jpa.entity.BaseEntity;
+import com.titi.pusher.domain.notification.NotificationCategory;
+import com.titi.pusher.domain.notification.NotificationStatus;
+import com.titi.pusher.domain.notification.NotificationType;
+import com.titi.pusher.domain.notification.ServiceInfo;
+import com.titi.pusher.domain.notification.TargetInfo;
+
+@Entity(name = "notifications")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationEntity extends BaseEntity {
+
+	@Id
+	private Long uid;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false, updatable = false)
+	private NotificationCategory notificationCategory;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false, updatable = false)
+	private NotificationType notificationType;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false)
+	private NotificationStatus notificationStatus;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false, updatable = false)
+	private TargetInfo.TargetType targetType;
+
+	@Column(nullable = false, updatable = false)
+	private String targetValue;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false, updatable = false)
+	private ServiceInfo.ServiceName serviceName;
+
+	@Column(nullable = false, updatable = false)
+	private String serviceRequestId;
+
+	@Column(nullable = false)
+	private LocalDateTime notifiedAt;
+
+}

--- a/src/main/java/com/titi/pusher/data/jpa/entity/NotificationHistoryEntity.java
+++ b/src/main/java/com/titi/pusher/data/jpa/entity/NotificationHistoryEntity.java
@@ -1,0 +1,34 @@
+package com.titi.pusher.data.jpa.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.titi.infrastructure.persistence.jpa.entity.BaseHistoryEntity;
+import com.titi.pusher.domain.notification.NotificationStatus;
+
+@Entity(name = "notification_histories")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationHistoryEntity extends BaseHistoryEntity {
+
+	@Id
+	private Long uid;
+
+	@Column(nullable = false, updatable = false)
+	private Long notificationId;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false, updatable = false)
+	private NotificationStatus notificationStatus;
+
+}

--- a/src/main/java/com/titi/pusher/data/jpa/repository/NotificationEntityRepository.java
+++ b/src/main/java/com/titi/pusher/data/jpa/repository/NotificationEntityRepository.java
@@ -1,0 +1,9 @@
+package com.titi.pusher.data.jpa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.titi.pusher.data.jpa.entity.NotificationEntity;
+
+public interface NotificationEntityRepository extends JpaRepository<NotificationEntity, Long> {
+
+}

--- a/src/main/java/com/titi/pusher/data/jpa/repository/NotificationHistoryEntityRepository.java
+++ b/src/main/java/com/titi/pusher/data/jpa/repository/NotificationHistoryEntityRepository.java
@@ -1,0 +1,9 @@
+package com.titi.pusher.data.jpa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.titi.pusher.data.jpa.entity.NotificationHistoryEntity;
+
+public interface NotificationHistoryEntityRepository extends JpaRepository<NotificationHistoryEntity, Long> {
+
+}

--- a/src/main/java/com/titi/pusher/domain/email/SimpleMailMessage.java
+++ b/src/main/java/com/titi/pusher/domain/email/SimpleMailMessage.java
@@ -1,0 +1,21 @@
+package com.titi.pusher.domain.email;
+
+import lombok.Builder;
+
+/**
+ * Domain model for sending a simple email message.
+ *
+ * @param from		The email address of the sender.
+ * @param to		The email address of the recipient.
+ * @param subject	The subject of the email.
+ * @param text		The text content of the email.
+ */
+@Builder
+public record SimpleMailMessage(
+	String from,
+	String to,
+	String subject,
+	String text
+) {
+
+}

--- a/src/main/java/com/titi/pusher/domain/notification/Notification.java
+++ b/src/main/java/com/titi/pusher/domain/notification/Notification.java
@@ -1,0 +1,43 @@
+package com.titi.pusher.domain.notification;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+import com.titi.common.util.UidUtils;
+
+@Builder(toBuilder = true)
+public record Notification(
+	Long notificationId,
+	NotificationCategory notificationCategory,
+	NotificationType notificationType,
+	NotificationStatus notificationStatus,
+	TargetInfo targetInfo,
+	ServiceInfo serviceInfo,
+	LocalDateTime notifiedAt
+) {
+
+	public static Notification ofEmail(NotificationCategory notificationCategory, String encryptedEmail, ServiceInfo serviceInfo) {
+		return Notification.builder()
+			.notificationId(UidUtils.generateUid())
+			.notificationCategory(notificationCategory)
+			.notificationType(NotificationType.EMAIL)
+			.targetInfo(new TargetInfo.EmailTargetInfo(encryptedEmail))
+			.serviceInfo(serviceInfo)
+			.build();
+	}
+
+	public Notification complete() {
+		return this.toBuilder()
+			.notificationStatus(NotificationStatus.COMPLETED)
+			.notifiedAt(LocalDateTime.now())
+			.build();
+	}
+
+	public Notification fail() {
+		return this.toBuilder()
+			.notificationStatus(NotificationStatus.FAILED)
+			.build();
+	}
+
+}

--- a/src/main/java/com/titi/pusher/domain/notification/Notification.java
+++ b/src/main/java/com/titi/pusher/domain/notification/Notification.java
@@ -17,12 +17,12 @@ public record Notification(
 	LocalDateTime notifiedAt
 ) {
 
-	public static Notification ofEmail(NotificationCategory notificationCategory, String encryptedEmail, ServiceInfo serviceInfo) {
+	public static Notification ofEmail(NotificationCategory notificationCategory, String email, ServiceInfo serviceInfo) {
 		return Notification.builder()
 			.notificationId(UidUtils.generateUid())
 			.notificationCategory(notificationCategory)
 			.notificationType(NotificationType.EMAIL)
-			.targetInfo(new TargetInfo.EmailTargetInfo(encryptedEmail))
+			.targetInfo(new TargetInfo.EmailTargetInfo(email))
 			.serviceInfo(serviceInfo)
 			.build();
 	}

--- a/src/main/java/com/titi/pusher/domain/notification/NotificationCategory.java
+++ b/src/main/java/com/titi/pusher/domain/notification/NotificationCategory.java
@@ -1,0 +1,20 @@
+package com.titi.pusher.domain.notification;
+
+public enum NotificationCategory {
+	/**
+	 * Informational notifications providing general details or updates.
+	 */
+	INFORMATION,
+	/**
+	 * Notifications used for important announcements or alerts.
+	 */
+	NOTICE,
+	/**
+	 * Notifications related to marketing or promotional activities.
+	 */
+	MARKETING,
+	/**
+	 * Notifications specifically used for authentication-related purposes, such as sending verification codes.
+	 */
+	AUTHENTICATION
+}

--- a/src/main/java/com/titi/pusher/domain/notification/NotificationStatus.java
+++ b/src/main/java/com/titi/pusher/domain/notification/NotificationStatus.java
@@ -1,0 +1,12 @@
+package com.titi.pusher.domain.notification;
+
+public enum NotificationStatus {
+	/**
+	 * Notification delivery completed successfully.
+	 */
+	COMPLETED,
+	/**
+	 * Notification delivery failed.
+	 */
+	FAILED
+}

--- a/src/main/java/com/titi/pusher/domain/notification/NotificationType.java
+++ b/src/main/java/com/titi/pusher/domain/notification/NotificationType.java
@@ -1,0 +1,8 @@
+package com.titi.pusher.domain.notification;
+
+public enum NotificationType {
+	/**
+	 * Notification delivered via email.
+	 */
+	EMAIL
+}

--- a/src/main/java/com/titi/pusher/domain/notification/ServiceInfo.java
+++ b/src/main/java/com/titi/pusher/domain/notification/ServiceInfo.java
@@ -1,0 +1,18 @@
+package com.titi.pusher.domain.notification;
+
+import lombok.Builder;
+
+@Builder
+public record ServiceInfo(
+	ServiceName name,
+	String requestId
+) {
+
+	public enum ServiceName {
+		/**
+		 * Authentication service module.
+		 */
+		AUTH
+	}
+
+}

--- a/src/main/java/com/titi/pusher/domain/notification/TargetInfo.java
+++ b/src/main/java/com/titi/pusher/domain/notification/TargetInfo.java
@@ -1,0 +1,32 @@
+package com.titi.pusher.domain.notification;
+
+public sealed interface TargetInfo {
+
+	TargetType getType();
+
+	String getTargetValue();
+
+	enum TargetType {
+		/**
+		 * Target value would be encrypted and stored as the recipient's email address in the database.
+		 */
+		EMAIL
+	}
+
+	record EmailTargetInfo(
+		String email
+	) implements TargetInfo {
+
+		@Override
+		public TargetType getType() {
+			return TargetType.EMAIL;
+		}
+
+		@Override
+		public String getTargetValue() {
+			return this.email;
+		}
+
+	}
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+# Spring Boot Common Application Properties
+# https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html
+
 server:
   port: 8080
   shutdown: graceful
@@ -25,6 +28,32 @@ spring:
     redis:
       host: localhost
       port: 6379
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${TITI_SMTP_GMAIL_DEV_USERNAME}
+    password: ${TITI_SMTP_GMAIL_DEV_PASSWORD}
+    # JavaMail Session Properties
+    # https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html
+    properties:
+      mail:
+        smtp:
+          auth: true # If true, attempt to authenticate the user using the AUTH command.
+          # Socket read timeout value in milliseconds. This timeout is implemented by java.net.Socket. Default is infinite timeout.
+          timeout: 5000
+          # Socket connection timeout value in milliseconds. This timeout is implemented by java.net.Socket. Default is infinite timeout.
+          connectiontimeout: 5000
+          # Socket write timeout value in milliseconds. This timeout is implemented by using a java.util.concurrent.ScheduledExecutorService
+          # per connection that schedules a thread to close the socket if the timeout expires. Thus, the overhead of using this timeout
+          # is one thread per connection. Default is infinite timeout.
+          writetimeout: 5000
+          starttls:
+            # If true, enables the use of the STARTTLS command (if supported by the server) to switch the connection to
+            # a TLS-protected connection before issuing any login commands. If the server does not support STARTTLS,
+            # the connection continues without the use of TLS; see the mail.smtp.starttls.required property to fail if
+            # STARTTLS isn't supported. Note that an appropriate trust store must configured so that the client will
+            # trust the server's certificate. Defaults to false.
+            enable: true
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,6 @@ logging:
 
 jwt:
   secret-key: abcdefghijklmnopqrstuwxzy0123456
+
+crypto:
+  secret-key: 12345678901234567890123456789012

--- a/src/test/java/com/titi/common/util/RandomGeneratorTest.java
+++ b/src/test/java/com/titi/common/util/RandomGeneratorTest.java
@@ -1,0 +1,52 @@
+package com.titi.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RandomGeneratorTest {
+
+	public static final String REGEX_NUMBERS = "[0-9]+";
+	public static final String REGEX_LOWERCASE = "[a-z]+";
+	public static final String REGEX_UPPERCASE = "[A-Z]+";
+	public static final String REGEX_NUMBERS_LOWERCASE = "[0-9a-z]+";
+	public static final String REGEX_NUMBERS_UPPERCASE = "[0-9A-Z]+";
+	public static final String REGEX_LOWERCASE_UPPERCASE = "[a-zA-Z]+";
+	public static final String REGEX_NUMBERS_LOWERCASE_UPPERCASE = "[0-9a-zA-Z]+";
+
+	public static Stream<Arguments> getGenerateMethodParametersAndRegex() {
+		return Stream.of(
+			Arguments.of(true, false, false, REGEX_NUMBERS),
+			Arguments.of(false, true, false, REGEX_LOWERCASE),
+			Arguments.of(false, false, true, REGEX_UPPERCASE),
+			Arguments.of(true, true, false, REGEX_NUMBERS_LOWERCASE),
+			Arguments.of(true, false, true, REGEX_NUMBERS_UPPERCASE),
+			Arguments.of(false, true, true, REGEX_LOWERCASE_UPPERCASE),
+			Arguments.of(true, true, true, REGEX_NUMBERS_LOWERCASE_UPPERCASE)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource(value = "getGenerateMethodParametersAndRegex")
+	void generateTest(boolean includeNumber, boolean includeLowercase, boolean includeUppercase, String regex) {
+		assertThat(RandomGenerator.generate(includeNumber, includeLowercase, includeUppercase, 10, true).matches(regex)).isTrue();
+	}
+
+	@ParameterizedTest
+	@MethodSource(value = "getGenerateMethodParametersAndRegex")
+	void generateTestDoesNotAllowDuplication(boolean includeNumber, boolean includeLowercase, boolean includeUppercase) {
+		final String result = RandomGenerator.generate(includeNumber, includeLowercase, includeUppercase, 10, false);
+		assertThat(result.length()).isEqualTo(result.chars().distinct().count());
+	}
+
+	@Test
+	void generateTestWhenIncludeNoneThenThrowIllegalArgumentException() {
+		assertThatCode(() -> RandomGenerator.generate(false, false, false, 10, true)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+}

--- a/src/test/java/com/titi/common/util/UidUtilsTest.java
+++ b/src/test/java/com/titi/common/util/UidUtilsTest.java
@@ -1,0 +1,44 @@
+package com.titi.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+class UidUtilsTest {
+
+	private static final long UID_TIMESTAMP_UNIT = 1_000_000;
+
+	@Test
+	void generateUidTestUidShouldBe19Digits() {
+		assertThat(Long.toString(UidUtils.generateUid()).length()).isEqualTo(19);
+	}
+
+	@Test
+	void getMinUidByLocalDateTimeTest() {
+		final LocalDateTime datetime = LocalDateTime.of(2022, 5, 1, 0, 0);
+		assertThat(UidUtils.getMinUidByLocalDateTime(datetime)).isEqualTo(1651363200000000000L);
+	}
+
+	@Test
+	void getMaxUidByLocalDateTimeTest() {
+		final LocalDateTime datetime = LocalDateTime.of(2022, 5, 1, 0, 0);
+		assertThat(UidUtils.getMaxUidByLocalDateTime(datetime)).isEqualTo(1651363200000999999L);
+	}
+
+	@Test
+	void getUnixTimestampFromUidTest() {
+		final long uid = UidUtils.generateUid(LocalDateTime.now());
+		final long unixTimestampFromUid = UidUtils.getUnixTimestampFromUid(uid);
+		assertThat(Long.toString(unixTimestampFromUid).substring(0, 13)).isEqualTo(Long.toString(uid).substring(0, 13));
+	}
+
+	@Test
+	void getLocalDatetimeFromUidTest() {
+		final long uid = UidUtils.generateUid(LocalDateTime.now());
+		final LocalDateTime localDateTimeFromUid = UidUtils.getLocalDatetimeFromUid(uid);
+		assertThat(Long.toString(UidUtils.generateUid(localDateTimeFromUid)).substring(0, 13)).isEqualTo(Long.toString(uid).substring(0, 13));
+	}
+
+}

--- a/src/test/java/com/titi/crypto/util/CryptoUtilsTest.java
+++ b/src/test/java/com/titi/crypto/util/CryptoUtilsTest.java
@@ -1,0 +1,23 @@
+package com.titi.crypto.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class CryptoUtilsTest {
+
+	private static final byte[] KEY_32BYTES = "12345678901234567890123456789012".getBytes();
+	private static final byte[] INPUT_DATA = "inputData".getBytes();
+	private final CryptoUtils cryptoUtils = new CryptoUtils(KEY_32BYTES);
+
+	@Test
+	void encryptTest() {
+		assertThatCode(() -> cryptoUtils.encrypt(INPUT_DATA)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void decryptTest() {
+		final byte[] encryptedData = cryptoUtils.encrypt(INPUT_DATA);
+		assertThat(cryptoUtils.decrypt(encryptedData)).isEqualTo(INPUT_DATA);
+	}
+}

--- a/src/test/java/com/titi/pusher/adapter/in/internal/InternalSendMailGatewayTest.java
+++ b/src/test/java/com/titi/pusher/adapter/in/internal/InternalSendMailGatewayTest.java
@@ -1,0 +1,51 @@
+package com.titi.pusher.adapter.in.internal;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.pusher.application.port.in.email.SendMailUseCase;
+import com.titi.pusher.domain.notification.Notification;
+import com.titi.pusher.domain.notification.NotificationStatus;
+
+@ExtendWith(MockitoExtension.class)
+class InternalSendMailGatewayTest {
+
+	@Mock
+	private SendMailUseCase sendMailUseCase;
+
+	@InjectMocks
+	private InternalSendMailGateway internalSendMailGateway;
+
+	private Notification createNotification() {
+		return Notification.builder()
+			.notificationId(1651363200000999999L)
+			.notificationStatus(NotificationStatus.COMPLETED)
+			.build();
+	}
+
+	@Test
+	void sendSimpleMessage_ShouldSendSimpleMessageAndReturnResponse() {
+		// given
+		final InternalSendMailGateway.SendSimpleMessageRequest request = InternalSendMailGateway.SendSimpleMessageRequest.builder()
+			.to("recipient@example.com")
+			.subject("Test Subject")
+			.text("Test Message")
+			.build();
+		given(sendMailUseCase.invoke(any())).willReturn(createNotification());
+
+		// when
+		final InternalSendMailGateway.SendSimpleMessageResponse response = internalSendMailGateway.sendSimpleMessage(request);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.messageId()).isEqualTo("1651363200000999999");
+		assertThat(response.messageStatus()).isEqualTo("COMPLETED");
+	}
+
+}

--- a/src/test/java/com/titi/pusher/adapter/out/persistence/NotificationPortAdapterTest.java
+++ b/src/test/java/com/titi/pusher/adapter/out/persistence/NotificationPortAdapterTest.java
@@ -1,0 +1,69 @@
+package com.titi.pusher.adapter.out.persistence;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.pusher.adapter.out.persistence.mapper.NotificationMapper;
+import com.titi.pusher.data.jpa.entity.NotificationEntity;
+import com.titi.pusher.data.jpa.entity.NotificationHistoryEntity;
+import com.titi.pusher.data.jpa.repository.NotificationEntityRepository;
+import com.titi.pusher.data.jpa.repository.NotificationHistoryEntityRepository;
+import com.titi.pusher.domain.notification.Notification;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationPortAdapterTest {
+
+	@Mock
+	private NotificationMapper notificationMapper;
+
+	@Mock
+	private NotificationEntityRepository notificationEntityRepository;
+
+	@Mock
+	private NotificationHistoryEntityRepository notificationHistoryEntityRepository;
+
+	@InjectMocks
+	private NotificationPortAdapter notificationPortAdapter;
+
+	@Test
+	void createTest() {
+		// given
+		final Notification notification = mock(Notification.class);
+		final NotificationEntity notificationEntity = mock(NotificationEntity.class);
+		final NotificationHistoryEntity historyEntity = mock(NotificationHistoryEntity.class);
+
+		given(notificationMapper.toEntity(notification)).willReturn(notificationEntity);
+		given(notificationMapper.toHistoryEntity(notification)).willReturn(historyEntity);
+
+		// when
+		notificationPortAdapter.create(notification);
+
+		// then
+		verify(notificationEntityRepository).save(notificationEntity);
+		verify(notificationHistoryEntityRepository).save(historyEntity);
+	}
+
+	@Test
+	void updateTest() {
+		// given
+		final Notification notification = mock(Notification.class);
+		final NotificationEntity notificationEntity = mock(NotificationEntity.class);
+		final NotificationHistoryEntity historyEntity = mock(NotificationHistoryEntity.class);
+
+		given(notificationMapper.toEntity(notification)).willReturn(notificationEntity);
+		given(notificationMapper.toHistoryEntity(notification)).willReturn(historyEntity);
+
+		// when
+		notificationPortAdapter.update(notification);
+
+		// then
+		verify(notificationEntityRepository).save(notificationEntity);
+		verify(notificationHistoryEntityRepository).save(historyEntity);
+	}
+
+}

--- a/src/test/java/com/titi/pusher/adapter/out/persistence/mapper/NotificationMapperTest.java
+++ b/src/test/java/com/titi/pusher/adapter/out/persistence/mapper/NotificationMapperTest.java
@@ -1,0 +1,77 @@
+package com.titi.pusher.adapter.out.persistence.mapper;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.crypto.util.CryptoUtils;
+import com.titi.pusher.data.jpa.entity.NotificationEntity;
+import com.titi.pusher.data.jpa.entity.NotificationHistoryEntity;
+import com.titi.pusher.domain.notification.Notification;
+import com.titi.pusher.domain.notification.NotificationCategory;
+import com.titi.pusher.domain.notification.ServiceInfo;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationMapperTest {
+
+	@Mock
+	private CryptoUtils cryptoUtils;
+
+	@InjectMocks
+	private NotificationMapper notificationMapper;
+
+	private Notification createNotificationOfEmail() {
+		return Notification.ofEmail(
+			NotificationCategory.AUTHENTICATION,
+			"ksp970306@gmail.com",
+			ServiceInfo.builder()
+				.requestId("requestId")
+				.name(ServiceInfo.ServiceName.AUTH)
+				.build()
+		);
+	}
+
+	@Test
+	void toEntityTestShouldMapNotificationToEntity() {
+		// given
+		final Notification notification = createNotificationOfEmail();
+		final String targetValue = "ksp970306@gmail.com";
+		given(cryptoUtils.encrypt(any(byte[].class))).willReturn(targetValue.getBytes());
+
+		// when
+		final NotificationEntity result = notificationMapper.toEntity(notification);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getUid()).isEqualTo(notification.notificationId());
+		assertThat(result.getNotificationCategory()).isEqualTo(notification.notificationCategory());
+		assertThat(result.getNotificationType()).isEqualTo(notification.notificationType());
+		assertThat(result.getNotificationStatus()).isEqualTo(notification.notificationStatus());
+		assertThat(result.getTargetType()).isEqualTo(notification.targetInfo().getType());
+		assertThat(result.getTargetValue()).isEqualTo(targetValue);
+		assertThat(result.getServiceName()).isEqualTo(notification.serviceInfo().name());
+		assertThat(result.getServiceRequestId()).isEqualTo(notification.serviceInfo().requestId());
+		assertThat(result.getNotifiedAt()).isEqualTo(notification.notifiedAt());
+	}
+
+	@Test
+	void toHistoryEntityTestShouldMapNotificationToHistoryEntity() {
+		// given
+		final Notification notification = createNotificationOfEmail();
+
+		// when
+		final NotificationHistoryEntity result = notificationMapper.toHistoryEntity(notification);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getUid()).isNotNull();
+		assertThat(result.getNotificationId()).isEqualTo(notification.notificationId());
+		assertThat(result.getNotificationStatus()).isEqualTo(notification.notificationStatus());
+	}
+
+}

--- a/src/test/java/com/titi/pusher/adapter/out/smtp/SendMailPortAdapterTest.java
+++ b/src/test/java/com/titi/pusher/adapter/out/smtp/SendMailPortAdapterTest.java
@@ -1,0 +1,39 @@
+package com.titi.pusher.adapter.out.smtp;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.titi.pusher.domain.email.SimpleMailMessage;
+
+@Disabled("Do not automate actual sending mail tests.")
+@SpringBootTest
+class SendMailPortAdapterTest {
+
+	@Autowired
+	private SendMailPortAdapter sendMailPortAdapter;
+
+	/**
+	 * Set the environment variables ${TITI_SMTP_GMAIL_TEST_USERNAME} and ${TITI_SMTP_GMAIL_TEST_PASSWORD} before running the tests.
+	 */
+	@Test
+	void sendSimpleMessageTest() {
+		// given
+		final SimpleMailMessage simpleMailMessage = SimpleMailMessage.builder()
+			.from("TimerTiTi.dev@gmail.com")
+			.to("ksp970306@gmail.com")
+			.subject("subject")
+			.text("text")
+			.build();
+
+		// when
+		final boolean isSuccessful = sendMailPortAdapter.sendSimpleMessage(simpleMailMessage);
+
+		// then
+		assertThat(isSuccessful).isTrue();
+	}
+
+}

--- a/src/test/java/com/titi/pusher/application/service/SendMailServiceTest.java
+++ b/src/test/java/com/titi/pusher/application/service/SendMailServiceTest.java
@@ -1,0 +1,63 @@
+package com.titi.pusher.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.pusher.application.port.in.email.SendMailUseCase;
+import com.titi.pusher.application.port.out.persistence.notification.CreateNotificationPort;
+import com.titi.pusher.application.port.out.persistence.notification.UpdateNotificationPort;
+import com.titi.pusher.application.port.out.smtp.SendMailPort;
+import com.titi.pusher.domain.email.SimpleMailMessage;
+import com.titi.pusher.domain.notification.Notification;
+import com.titi.pusher.domain.notification.NotificationCategory;
+import com.titi.pusher.domain.notification.ServiceInfo;
+
+@ExtendWith(MockitoExtension.class)
+class SendMailServiceTest {
+
+	@Mock
+	private SendMailPort sendMailPort;
+
+	@Mock
+	private CreateNotificationPort createNotificationPort;
+
+	@Mock
+	private UpdateNotificationPort updateNotificationPort;
+
+	@InjectMocks
+	private SendMailService sendMailService;
+
+	@Test
+	void invokeWithToSimpleMessageShouldCreateNotificationAndSendMail() {
+		// given
+		final SendMailUseCase.Command.ToSimpleMessage message = createSampleToSimpleMessage();
+
+		// when
+		final Notification notification = sendMailService.invoke(message);
+
+		// then
+		assertThat(notification).isNotNull();
+		verify(createNotificationPort, times(1)).create(any(Notification.class));
+		verify(sendMailPort, times(1)).sendSimpleMessage(any(SimpleMailMessage.class));
+		verify(updateNotificationPort, times(1)).update(any(Notification.class));
+	}
+
+	private SendMailUseCase.Command.ToSimpleMessage createSampleToSimpleMessage() {
+		return SendMailUseCase.Command.ToSimpleMessage.builder()
+			.to("to@to.com")
+			.from("from@from.com")
+			.subject("subject")
+			.text("text")
+			.serviceName(ServiceInfo.ServiceName.AUTH)
+			.serviceRequestId("serviceRequestId")
+			.notificationCategory(NotificationCategory.AUTHENTICATION)
+			.build();
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,34 @@
+spring:
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: none
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/titi?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    username: root
+    password: 1234
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${TITI_SMTP_GMAIL_TEST_USERNAME}
+    password: ${TITI_SMTP_GMAIL_TEST_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+jwt:
+  secret-key: abcdefghijklmnopqrstuwxzy0123456
+
+crypto:
+  secret-key: 12345678901234567890123456789012


### PR DESCRIPTION
### 리뷰 요청
- [ ] 🙋 꼭 리뷰를 받고 싶어요!
- [ ] 리뷰 긴급도: D-x

### 개요
<!--
ex) Issue: Resolve #3
이슈 번호 앞에 Resolve를 붙이면, merge 시 자동으로 issue도 close됩니다.
-->
- Issue: Resolve #4
- Tech Spec: https://www.notion.so/timertiti/dfff19ee1aa84e25b9b9087241c8533b
- Figma:
---
### 변경사항

- 이메일 전송 기능을 개발했어요. 간단한 텍스트 정도 보낼 수 있는 기능이고, 필요 시 html 형태를 보내는 기능 확장도 고려하여 usecase를 설계하였어요.
- pusher 모듈을 추가했어요. 이는 이메일 뿐만 아니라 Kakao 알림톡, SMS, App push 등 사용자에게 알림을 보낼 수 있는 기능들을 포함해요.
- 다른 모듈에서 pusher 모듈의 기능을 이용하려면 gateway를 사용하도록 구현해주세요. gateway 의존은 out port adapter에서 해주세요.
    - MSA로 전환 시 깔끔하게 전환하기 위해 이와 같이 구현했어요.
- config 패키지는 infrastructure 패지키와 동일하게, MSA로 전환할 경우 각 모듈에서 필요한 경우 해당 패키지를 가져가서 사용하려는 의도로 구분하였어요.
- DB에 개인정보 저장 시 CryptoUtils을 사용하여 암호화 한 뒤 저장해주세요.
- History 엔티티는 NoSQL 전환 고려 및 RDB 성능 이슈(FK 제약조건 검사)를 고려하여 설계하였어요. 참고해주세요.
- 이 외에도 유틸 클래스를 몇 개 추가했어요. 유용하게 사용해주세요 :)


---

### 리뷰 받고 싶은 내용
