### PR TITLE
인증 코드 발급 API auth_key response 추가 및 응답 코드 개선

### DIFF
--- a/src/main/java/com/titi/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/titi/exception/ControllerExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.titi.exception;
 
 import static com.titi.titi_common_lib.constant.Constants.*;
-import static com.titi.titi_common_lib.constant.TiTiErrorCode.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,6 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -24,7 +24,6 @@ import org.springframework.web.multipart.support.MissingServletRequestPartExcept
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 
-import com.titi.titi_common_lib.constant.TiTiErrorCode;
 import com.titi.titi_common_lib.dto.ErrorResponse;
 import com.titi.titi_common_lib.dto.ErrorResponse.FieldError;
 
@@ -38,7 +37,7 @@ public class ControllerExceptionHandler {
 	 */
 	@ExceptionHandler
 	protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
-		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, this.getErrors(e.getConstraintViolations()));
+		final ErrorResponse response = ErrorResponse.of(TiTiErrorCodes.INPUT_VALUE_INVALID, this.getErrors(e.getConstraintViolations()));
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -49,7 +48,7 @@ public class ControllerExceptionHandler {
 	 */
 	@ExceptionHandler
 	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, this.getErrors(e.getBindingResult()));
+		final ErrorResponse response = ErrorResponse.of(TiTiErrorCodes.INPUT_VALUE_INVALID, this.getErrors(e.getBindingResult()));
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -60,7 +59,7 @@ public class ControllerExceptionHandler {
 	 */
 	@ExceptionHandler
 	protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
-		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, this.getErrors(e.getBindingResult()));
+		final ErrorResponse response = ErrorResponse.of(TiTiErrorCodes.INPUT_VALUE_INVALID, this.getErrors(e.getBindingResult()));
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -69,8 +68,8 @@ public class ControllerExceptionHandler {
 	 */
 	@ExceptionHandler({MissingServletRequestParameterException.class, MissingServletRequestPartException.class})
 	protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(Exception e) {
-		final List<FieldError> errors = FieldError.of(this.getRequestParam(e), EMPTY, REQUEST_PARAMETER_MISSING.getMessage());
-		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, errors);
+		final List<FieldError> errors = FieldError.of(this.getRequestParam(e), EMPTY, TiTiErrorCodes.REQUEST_PARAMETER_MISSING.getMessage());
+		final ErrorResponse response = ErrorResponse.of(TiTiErrorCodes.INPUT_VALUE_INVALID, errors);
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -81,7 +80,7 @@ public class ControllerExceptionHandler {
 	protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
 		final String value = e.getValue() == null ? EMPTY : e.getValue().toString();
 		final List<FieldError> errors = FieldError.of(e.getName(), value, e.getErrorCode());
-		final ErrorResponse response = ErrorResponse.of(INPUT_TYPE_INVALID, errors);
+		final ErrorResponse response = ErrorResponse.of(TiTiErrorCodes.INPUT_TYPE_INVALID, errors);
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -90,7 +89,7 @@ public class ControllerExceptionHandler {
 	 */
 	@ExceptionHandler
 	protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
-		final ErrorResponse response = ErrorResponse.of(HTTP_MESSAGE_NOT_READABLE);
+		final ErrorResponse response = ErrorResponse.of(TiTiErrorCodes.HTTP_MESSAGE_NOT_READABLE);
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -98,9 +97,8 @@ public class ControllerExceptionHandler {
 	 * 지원하지 않는 <b>HTTP method</b> 호출할 경우 예외 처리
 	 */
 	@ExceptionHandler
-	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
-		HttpRequestMethodNotSupportedException e) {
-		final ErrorResponse response = ErrorResponse.of(METHOD_NOT_ALLOWED);
+	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+		final ErrorResponse response = ErrorResponse.of(TiTiErrorCodes.METHOD_NOT_ALLOWED);
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -109,9 +107,8 @@ public class ControllerExceptionHandler {
 	 */
 	@ExceptionHandler
 	protected ResponseEntity<ErrorResponse> handleTiTiException(TiTiException e) {
-		final TiTiErrorCode errorCode = e.getErrorCode();
-		final ErrorResponse response = ErrorResponse.of(errorCode, e.getErrors());
-		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+		final ErrorResponse response = ErrorResponse.of(e.getErrorCode(), e.getErrors());
+		return new ResponseEntity<>(response, HttpStatusCode.valueOf(e.getErrorCode().getStatus()));
 	}
 
 	/**
@@ -119,7 +116,7 @@ public class ControllerExceptionHandler {
 	 */
 	@ExceptionHandler
 	protected ResponseEntity<ErrorResponse> handleException(Exception e) {
-		final ErrorResponse response = ErrorResponse.of(INTERNAL_SERVER_ERROR);
+		final ErrorResponse response = ErrorResponse.of(TiTiErrorCodes.INTERNAL_SERVER_ERROR);
 		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 

--- a/src/main/java/com/titi/exception/TiTiErrorCodes.java
+++ b/src/main/java/com/titi/exception/TiTiErrorCodes.java
@@ -1,11 +1,13 @@
-package com.titi.titi_common_lib.constant;
+package com.titi.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum TiTiErrorCode {
+public enum TiTiErrorCodes {
+
+	GENERATE_AUTH_CODE_FAILURE(500, "AU7000", "Failed to generate and transmit the authentication code. Please try again later."),
 
 	INPUT_VALUE_INVALID(400, "E9000", "Invalid input value."),
 	INPUT_TYPE_INVALID(400, "E9001", "Invalid input type."),
@@ -15,7 +17,8 @@ public enum TiTiErrorCode {
 	REQUEST_HEADER_MISSING(400, "E9005", "Request header is missing."),
 	AUTHENTICATION_FAILURE(401, "E9006", "Authentication failed."),
 	INSUFFICIENT_AUTHORITY(403, "E9007", "Insufficient authority or permissions."),
-	INTERNAL_SERVER_ERROR(500, "E9999", "Internal server error.");
+	INTERNAL_SERVER_ERROR(500, "E9999", "Internal server error."),
+	;
 
 	private final int status;
 	private final String code;

--- a/src/main/java/com/titi/exception/TiTiException.java
+++ b/src/main/java/com/titi/exception/TiTiException.java
@@ -5,22 +5,21 @@ import java.util.List;
 
 import lombok.Getter;
 
-import com.titi.titi_common_lib.constant.TiTiErrorCode;
 import com.titi.titi_common_lib.dto.ErrorResponse;
 
 @Getter
 public class TiTiException extends RuntimeException {
 
-	private final TiTiErrorCode errorCode;
+	private final TiTiErrorCodes errorCode;
 	private final List<ErrorResponse.FieldError> errors;
 
-	public TiTiException(TiTiErrorCode errorCode, List<ErrorResponse.FieldError> errors) {
+	public TiTiException(TiTiErrorCodes errorCode, List<ErrorResponse.FieldError> errors) {
 		super(errorCode.getMessage());
 		this.errorCode = errorCode;
 		this.errors = errors;
 	}
 
-	public TiTiException(TiTiErrorCode errorCode) {
+	public TiTiException(TiTiErrorCodes errorCode) {
 		super(errorCode.getMessage());
 		this.errorCode = errorCode;
 		this.errors = new ArrayList<>();

--- a/src/main/java/com/titi/security/authentication/exception/AccessDeniedHandlerImpl.java
+++ b/src/main/java/com/titi/security/authentication/exception/AccessDeniedHandlerImpl.java
@@ -1,7 +1,5 @@
 package com.titi.security.authentication.exception;
 
-import static com.titi.titi_common_lib.constant.TiTiErrorCode.*;
-
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -16,6 +14,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
+import com.titi.exception.TiTiErrorCodes;
 import com.titi.titi_common_lib.dto.ErrorResponse;
 
 @Component
@@ -30,7 +29,7 @@ public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
 		try (OutputStream os = response.getOutputStream()) {
-			objectMapper.writeValue(os, ErrorResponse.of(INSUFFICIENT_AUTHORITY));
+			objectMapper.writeValue(os, ErrorResponse.of(TiTiErrorCodes.INSUFFICIENT_AUTHORITY));
 			os.flush();
 		}
 	}

--- a/src/main/java/com/titi/security/authentication/exception/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/titi/security/authentication/exception/AuthenticationEntryPointImpl.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
+import com.titi.exception.TiTiErrorCodes;
 import com.titi.titi_common_lib.dto.ErrorResponse;
 
 @Component

--- a/src/main/java/com/titi/security/authentication/exception/TiTiAuthenticationException.java
+++ b/src/main/java/com/titi/security/authentication/exception/TiTiAuthenticationException.java
@@ -1,24 +1,22 @@
 package com.titi.security.authentication.exception;
 
-import static com.titi.titi_common_lib.constant.TiTiErrorCode.*;
-
 import java.util.List;
 
 import org.springframework.security.core.AuthenticationException;
 
 import lombok.Getter;
 
-import com.titi.titi_common_lib.constant.TiTiErrorCode;
+import com.titi.exception.TiTiErrorCodes;
 import com.titi.titi_common_lib.dto.ErrorResponse.FieldError;
 
 @Getter
 public class TiTiAuthenticationException extends AuthenticationException {
 
-	private final TiTiErrorCode errorCode = AUTHENTICATION_FAILURE;
+	private final TiTiErrorCodes errorCode = TiTiErrorCodes.AUTHENTICATION_FAILURE;
 	private final List<FieldError> errors;
 
 	public TiTiAuthenticationException(List<FieldError> errors) {
-		super(AUTHENTICATION_FAILURE.getMessage());
+		super(TiTiErrorCodes.AUTHENTICATION_FAILURE.getMessage());
 		this.errors = errors;
 	}
 

--- a/src/main/java/com/titi/titi_auth/adapter/in/web/api/AuthApi.java
+++ b/src/main/java/com/titi/titi_auth/adapter/in/web/api/AuthApi.java
@@ -14,7 +14,7 @@ interface AuthApi {
 	@AllArgsConstructor
 	enum ResultCode {
 		GENERATE_AUTH_CODE_SUCCESS(201, "AU1000", "Successfully generated and transmitted the authentication code."),
-		GENERATE_AUTH_CODE_FAILURE(200, "AU1001", "Failed to generate and transmit the authentication code. Please try again later."),
+		VERIFY_AUTH_CODE_SUCCESS(200, "AU1001", "Successfully verifying the authentication code issues an authentication token."),
 		;
 
 		private final int status;

--- a/src/main/java/com/titi/titi_auth/adapter/out/cache/AuthCodePortAdapter.java
+++ b/src/main/java/com/titi/titi_auth/adapter/out/cache/AuthCodePortAdapter.java
@@ -1,13 +1,13 @@
 package com.titi.titi_auth.adapter.out.cache;
 
 import static com.titi.titi_common_lib.constant.Constants.*;
-import static com.titi.titi_common_lib.constant.TiTiErrorCode.*;
 
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.titi.exception.TiTiErrorCodes;
 import com.titi.exception.TiTiException;
 import com.titi.infrastructure.cache.CacheManager;
 import com.titi.titi_auth.application.port.out.PutAuthCodePort;
@@ -23,14 +23,15 @@ class AuthCodePortAdapter implements PutAuthCodePort {
 	private final CacheManager cacheManager;
 
 	@Override
-	public void put(AuthCode authCode) {
+	public String put(AuthCode authCode) {
 		final String key = this.getCacheKey(authCode);
 		try {
 			this.cacheManager.put(key, JacksonHelper.toJson(authCode), AuthCacheKeys.AUTH_CODE.getTimeToLive());
 			log.info("[put] Success to put authCode in cache. key: {}.", key);
+			return key;
 		} catch (Exception e) {
 			log.error("[put] Fail to put authCode in cache. key: {}.", key, e);
-			throw new TiTiException(INTERNAL_SERVER_ERROR);
+			throw new TiTiException(TiTiErrorCodes.GENERATE_AUTH_CODE_FAILURE);
 		}
 	}
 

--- a/src/main/java/com/titi/titi_auth/application/port/in/GenerateAuthCodeUseCase.java
+++ b/src/main/java/com/titi/titi_auth/application/port/in/GenerateAuthCodeUseCase.java
@@ -18,7 +18,7 @@ public interface GenerateAuthCodeUseCase {
 		return RandomGenerator.generate(true, true, true, AUTH_CODE_LENGTH, false);
 	}
 
-	boolean invoke(@Valid Command command);
+	String invoke(@Valid Command command);
 
 	sealed interface Command {
 

--- a/src/main/java/com/titi/titi_auth/application/port/out/PutAuthCodePort.java
+++ b/src/main/java/com/titi/titi_auth/application/port/out/PutAuthCodePort.java
@@ -4,6 +4,6 @@ import com.titi.titi_auth.domain.AuthCode;
 
 public interface PutAuthCodePort {
 
-	void put(AuthCode authCode);
+	String put(AuthCode authCode);
 
 }

--- a/src/main/java/com/titi/titi_auth/application/port/out/SendAuthCodePort.java
+++ b/src/main/java/com/titi/titi_auth/application/port/out/SendAuthCodePort.java
@@ -7,6 +7,6 @@ public interface SendAuthCodePort {
 	String NOTIFICATION_CATEGORY = "AUTHENTICATION";
 	String MESSAGE_STATUS_COMPLETED = "COMPLETED";
 
-	boolean send(AuthCode authCode);
+	void send(AuthCode authCode);
 
 }

--- a/src/main/java/com/titi/titi_auth/application/service/GenerateAuthCodeService.java
+++ b/src/main/java/com/titi/titi_auth/application/service/GenerateAuthCodeService.java
@@ -18,7 +18,7 @@ class GenerateAuthCodeService implements GenerateAuthCodeUseCase {
 	private final SendAuthCodePort sendAuthCodePort;
 
 	@Override
-	public boolean invoke(Command command) {
+	public String invoke(Command command) {
 		final String generatedAuthCode = GenerateAuthCodeUseCase.generateAuthCode();
 		final AuthCode authCode = switch (command) {
 			case Command.ToEmail cmd -> AuthCode.builder()
@@ -28,8 +28,9 @@ class GenerateAuthCodeService implements GenerateAuthCodeUseCase {
 				.targetValue(cmd.email())
 				.build();
 		};
-		this.putAuthCodePort.put(authCode);
-		return this.sendAuthCodePort.send(authCode);
+		final String authKey = this.putAuthCodePort.put(authCode);
+		this.sendAuthCodePort.send(authCode);
+		return authKey;
 	}
 
 }

--- a/src/main/java/com/titi/titi_common_lib/dto/ErrorResponse.java
+++ b/src/main/java/com/titi/titi_common_lib/dto/ErrorResponse.java
@@ -7,7 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import com.titi.titi_common_lib.constant.TiTiErrorCode;
+import com.titi.exception.TiTiErrorCodes;
 
 @Getter
 public class ErrorResponse {
@@ -16,23 +16,23 @@ public class ErrorResponse {
 	private final String message;
 	private final List<FieldError> errors;
 
-	private ErrorResponse(TiTiErrorCode errorCode, List<FieldError> errors) {
+	private ErrorResponse(TiTiErrorCodes errorCode, List<FieldError> errors) {
 		this.code = errorCode.getCode();
 		this.message = errorCode.getMessage();
 		this.errors = errors;
 	}
 
-	private ErrorResponse(TiTiErrorCode errorCode) {
+	private ErrorResponse(TiTiErrorCodes errorCode) {
 		this.code = errorCode.getCode();
 		this.message = errorCode.getMessage();
 		this.errors = new ArrayList<>();
 	}
 
-	public static ErrorResponse of(final TiTiErrorCode errorCode) {
+	public static ErrorResponse of(final TiTiErrorCodes errorCode) {
 		return new ErrorResponse(errorCode);
 	}
 
-	public static ErrorResponse of(final TiTiErrorCode errorCode, final List<FieldError> errors) {
+	public static ErrorResponse of(final TiTiErrorCodes errorCode, final List<FieldError> errors) {
 		return new ErrorResponse(errorCode, errors);
 	}
 
@@ -56,7 +56,7 @@ public class ErrorResponse {
 			return fieldErrors;
 		}
 
-		public static List<FieldError> of(String field, String value, TiTiErrorCode errorCode) {
+		public static List<FieldError> of(String field, String value, TiTiErrorCodes errorCode) {
 			final List<FieldError> fieldErrors = new ArrayList<>();
 			fieldErrors.add(new FieldError(field, value, errorCode.getMessage()));
 			return fieldErrors;

--- a/src/test/java/com/titi/titi_auth/adapter/out/cache/AuthCodePortAdapterTest.java
+++ b/src/test/java/com/titi/titi_auth/adapter/out/cache/AuthCodePortAdapterTest.java
@@ -30,9 +30,10 @@ class AuthCodePortAdapterTest {
 		final AuthCode authCode = new AuthCode(AuthenticationType.SIGN_UP, "123", TargetType.EMAIL, "test@example.com");
 
 		// when
-		authCodePortAdapter.put(authCode);
+		final String authKey = authCodePortAdapter.put(authCode);
 
 		// then
+		assertThat(authKey).isNotNull();
 		verify(cacheManager, times(1)).put(anyString(), anyString(), anyLong());
 	}
 

--- a/src/test/java/com/titi/titi_auth/adapter/out/pusher/SendAuthCodePortAdapterTest.java
+++ b/src/test/java/com/titi/titi_auth/adapter/out/pusher/SendAuthCodePortAdapterTest.java
@@ -3,12 +3,14 @@ package com.titi.titi_auth.adapter.out.pusher;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.titi.exception.TiTiException;
 import com.titi.titi_auth.application.common.constant.AuthConstants;
 import com.titi.titi_auth.application.port.out.SendAuthCodePort;
 import com.titi.titi_auth.domain.AuthCode;
@@ -48,10 +50,9 @@ class SendAuthCodePortAdapterTest {
 		);
 
 		// when
-		final boolean result = sendAuthCodePortAdapter.send(authCode);
+		sendAuthCodePortAdapter.send(authCode);
 
 		// then
-		assertThat(result).isTrue();
 		verify(internalSendMailGateway, times(1)).sendSimpleMessage(eq(expectedRequest));
 	}
 
@@ -67,18 +68,13 @@ class SendAuthCodePortAdapterTest {
 			.serviceName(AuthConstants.SERVICE_NAME)
 			.serviceRequestId("AUTH_CODE_NOTI_dq2enrB2Oxn6IovRYEilwvc/iqyKHaozSy3D00pEiOY=")
 			.build();
-		given(internalSendMailGateway.sendSimpleMessage(expectedRequest)).willReturn(
-			SendMessageResponse.builder()
-				.messageStatus("FAILED")
-				.messageId("987654321")
-				.build()
-		);
+		given(internalSendMailGateway.sendSimpleMessage(expectedRequest)).willThrow(TiTiException.class);
 
 		// when
-		final boolean result = sendAuthCodePortAdapter.send(authCode);
+		final ThrowableAssert.ThrowingCallable throwingCallable = () -> sendAuthCodePortAdapter.send(authCode);
 
 		// then
-		assertThat(result).isFalse();
+		assertThatCode(throwingCallable).isInstanceOf(TiTiException.class);
 		verify(internalSendMailGateway, times(1)).sendSimpleMessage(eq(expectedRequest));
 	}
 }

--- a/src/test/java/com/titi/titi_common_lib/util/JwtUtilsTest.java
+++ b/src/test/java/com/titi/titi_common_lib/util/JwtUtilsTest.java
@@ -24,7 +24,7 @@ class JwtUtilsTest {
 	private final static String JWT_ID = "jwtId";
 	public static final Instant NOW = Instant.parse("2024-02-11T10:00:00.000000000Z");
 	private final static Date EXPIRED_DATE = Date.from(NOW.minus(1, TimeUnit.DAYS.toChronoUnit()));
-	private final static Date EXPIRATION_DATE = Date.from(NOW.plus(1, TimeUnit.DAYS.toChronoUnit()));
+	private final static Date EXPIRATION_DATE = Date.from(NOW.plus(99999999, TimeUnit.DAYS.toChronoUnit()));
 	private final static Date ISSUED_DATE = Date.from(NOW);
 	private static final JwtUtils.Payload PAYLOAD = JwtUtils.Payload.builder()
 		.registeredClaim(


### PR DESCRIPTION
### 리뷰 요청
- [ ] 🙋 꼭 리뷰를 받고 싶어요!
- [ ] 리뷰 긴급도: D-x

### 개요
<!--
ex) Issue: Resolve #3
이슈 번호 앞에 Resolve를 붙이면, merge 시 자동으로 issue도 close됩니다.
-->
- Issue: Resolve #43 
- Tech Spec: https://www.notion.so/timertiti/dfff19ee1aa84e25b9b9087241c8533b
- Figma:
---
### 변경사항
- 잘못된 ErrorCode 의존성 구조를 올바르게 수정했어요. 앞으로 모든 ErrorCode는 TiTiErrorCodes.java에서 관리해요.
- sendAuthCode 및 putAuthCode를 실패 시 TiTiException을 throw하도록 변경했어요.
- 응답 코드 AU1001을 AU7000으로 변경했어요.
- PutAuthCodePort를 authKey를 반환하도록 변경했어요.
- generateAuthCode API Response body에 authKey를 추가했어요.
- JwtUtilTest.java에서 EXPIRATION_DATE를 현실적으로 만료될 수 없는 날짜로 변경했어요.


---

### 리뷰 받고 싶은 내용
