### PR TITLE
일반 로그인 API 개발

### DIFF
--- a/src/main/java/com/titi/security/authentication/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/titi/security/authentication/jwt/JwtAuthenticationProvider.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 	public Authentication authenticate(Authentication authentication) throws AuthenticationException {
 		final String jwt = ((JwtAuthenticationToken)authentication).getCredentials();
 		try {
-			final Claims claims = jwtUtils.getPayloads(jwt);
+			final Claims claims = jwtUtils.getPayloads(jwt, SecurityConstants.ACCESS_TOKEN);
 			this.checkTokenRevocation(claims.getId());
 			final Long memberId = Long.valueOf(claims.getSubject());
 			return JwtAuthenticationToken.of(memberId, jwt, getAuthorities(claims));

--- a/src/main/java/com/titi/security/constant/SecurityConstants.java
+++ b/src/main/java/com/titi/security/constant/SecurityConstants.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 public final class SecurityConstants {
 
 	public static final String REQUEST_HEADER_AUTHORIZATION = "Authorization";
+	public static final String ACCESS_TOKEN = "accessToken";
 
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	public static final class AuthenticationWhiteList {

--- a/src/main/java/com/titi/titi_auth/application/common/constant/AuthConstants.java
+++ b/src/main/java/com/titi/titi_auth/application/common/constant/AuthConstants.java
@@ -8,5 +8,6 @@ public final class AuthConstants {
 
 	public static final String SERVICE_NAME = "AUTH";
 	public static final String JWT_ISSUER = "TiTi-Auth";
+	public static final String AUTH_TOKEN = "authToken";
 
 }

--- a/src/main/java/com/titi/titi_auth/application/service/VerifyAuthCodeService.java
+++ b/src/main/java/com/titi/titi_auth/application/service/VerifyAuthCodeService.java
@@ -2,6 +2,7 @@ package com.titi.titi_auth.application.service;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -58,6 +59,7 @@ public class VerifyAuthCodeService implements VerifyAuthCodeUseCase {
 						.jwtId(UUID.randomUUID().toString())
 						.build()
 				)
+				.additionalClaims(Map.of(JwtUtils.Payload.TYPE, AuthConstants.AUTH_TOKEN))
 				.build()
 		);
 	}

--- a/src/main/java/com/titi/titi_common_lib/util/JwtUtils.java
+++ b/src/main/java/com/titi/titi_common_lib/util/JwtUtils.java
@@ -35,13 +35,18 @@ public class JwtUtils {
 			.compact();
 	}
 
-	public Claims getPayloads(String jwt) throws IllegalArgumentException {
+	public Claims getPayloads(String jwt, String type) throws IllegalArgumentException {
 		try {
-			return (Claims)Jwts.parser()
+			final Claims claims = (Claims)Jwts.parser()
 				.verifyWith(Keys.hmacShaKeyFor(this.secretKey))
 				.build()
 				.parse(jwt)
 				.getPayload();
+			final String claimType = claims.get(Payload.TYPE, String.class);
+			if (!claimType.equals(type)) {
+				throw new IllegalArgumentException("JWT token is invalid. Type is invalid. : " + claimType);
+			}
+			return claims;
 		} catch (JwtException e) {
 			throw new IllegalArgumentException("JWT token is invalid. " + e.getMessage(), e);
 		}
@@ -52,6 +57,8 @@ public class JwtUtils {
 		@NonNull RegisteredClaim registeredClaim,
 		@Nullable Map<String, Object> additionalClaims
 	) {
+
+		public static final String TYPE = "type";
 
 		/**
 		 * Represents the registered claims in a JSON Web Token (JWT).

--- a/src/main/java/com/titi/titi_user/adapter/in/web/api/LoginController.java
+++ b/src/main/java/com/titi/titi_user/adapter/in/web/api/LoginController.java
@@ -1,0 +1,85 @@
+package com.titi.titi_user.adapter.in.web.api;
+
+import org.hibernate.validator.constraints.Length;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+import com.titi.titi_user.application.port.in.LoginUseCase;
+import com.titi.titi_user.common.TiTiUserBusinessCodes;
+import com.titi.titi_user.domain.member.EncodedEncryptedPassword;
+
+@RestController
+@RequiredArgsConstructor
+class LoginController implements UserApi {
+
+	private final LoginUseCase loginUseCase;
+
+	@Operation(summary = "login API", description = "You have successfully logged in.")
+	@PostMapping(value = "/members/login", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<LoginResponseBody> login(@Valid @RequestBody LoginRequestBody requestBody) {
+		final LoginUseCase.Result result = this.loginUseCase.invoke(
+			LoginUseCase.Command.builder()
+				.username(requestBody.username())
+				.encodedEncryptedPassword(EncodedEncryptedPassword.builder().value(requestBody.encodedEncryptedPassword()).build())
+				.build()
+		);
+		return ResponseEntity.status(TiTiUserBusinessCodes.LOGIN_SUCCESS.getStatus())
+			.body(
+				LoginResponseBody.builder()
+					.code(TiTiUserBusinessCodes.LOGIN_SUCCESS.getCode())
+					.message(TiTiUserBusinessCodes.LOGIN_SUCCESS.getMessage())
+					.accessToken(result.accessToken())
+					.refreshToken(result.refreshToken())
+					.build()
+			);
+	}
+
+	@Builder
+	@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+	public record LoginRequestBody(
+		@Schema(
+			description = "username in Email format.",
+			requiredMode = Schema.RequiredMode.REQUIRED
+		) @NotBlank @Email @Length(max = 30) String username,
+		@Schema(
+			description = "it is encrypted using AES-256 to wrap the raw_password then encoded using base64url.",
+			requiredMode = Schema.RequiredMode.REQUIRED,
+			example = "6o171NOMWMJ2BMgouXrOr82lFLFFo-hA9qphcA=="
+		) @NotBlank String encodedEncryptedPassword
+	) {
+
+	}
+
+	@Builder
+	@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+	public record LoginResponseBody(
+		@Schema(
+			description = "TiTi Business code."
+		) String code,
+		@Schema(
+			description = "API result message."
+		) String message,
+		@Schema(
+			description = "Access Token for self-authentication (Validity : 30 minutes)"
+		) String accessToken,
+		@Schema(
+			description = "Refresh Token for reissuing the Access Token (Validity : 2 weeks)"
+		) String refreshToken
+	) {
+
+	}
+
+}

--- a/src/main/java/com/titi/titi_user/adapter/in/web/api/RegisterMemberController.java
+++ b/src/main/java/com/titi/titi_user/adapter/in/web/api/RegisterMemberController.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.titi.titi_user.application.port.in.RegisterMemberUseCase;
 import com.titi.titi_user.common.TiTiUserBusinessCodes;
+import com.titi.titi_user.domain.member.EncodedEncryptedPassword;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,7 +33,7 @@ class RegisterMemberController implements UserApi {
 		this.registerMemberUseCase.invoke(
 			RegisterMemberUseCase.Command.builder()
 				.username(requestBody.username())
-				.encodedEncryptedPassword(requestBody.encodedEncryptedPassword())
+				.encodedEncryptedPassword(EncodedEncryptedPassword.builder().value(requestBody.encodedEncryptedPassword()).build())
 				.nickname(requestBody.nickname())
 				.authToken(requestBody.authToken())
 				.build()

--- a/src/main/java/com/titi/titi_user/application/common/constant/UserConstants.java
+++ b/src/main/java/com/titi/titi_user/application/common/constant/UserConstants.java
@@ -1,0 +1,25 @@
+package com.titi.titi_user.application.common.constant;
+
+import static com.titi.titi_common_lib.constant.Constants.*;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserConstants {
+
+	public static final String SERVICE_NAME = "USER";
+	public static final String JWT_ISSUER = "TiTi-User";
+	public static final String AUTH_TOKEN = "authToken";
+	public static final String ACCESS_TOKEN = "accessToken";
+	public static final String REFRESH_TOKEN = "refreshToken";
+	/**
+	 * 30 minutes
+	 */
+	public static final int ACCESS_TOKEN_EXPIRATION_TIME = 30 * 60 * SECONDS;
+	/**
+	 * 2 weeks
+	 */
+	public static final int REFRESH_TOKEN_EXPIRATION_TIME = 14 * 24 * 60 * 60 * SECONDS;
+
+}

--- a/src/main/java/com/titi/titi_user/application/port/in/LoginUseCase.java
+++ b/src/main/java/com/titi/titi_user/application/port/in/LoginUseCase.java
@@ -1,0 +1,27 @@
+package com.titi.titi_user.application.port.in;
+
+import lombok.Builder;
+
+import com.titi.titi_user.domain.member.EncodedEncryptedPassword;
+
+public interface LoginUseCase {
+
+	Result invoke(Command command);
+
+	@Builder
+	record Command(
+		String username,
+		EncodedEncryptedPassword encodedEncryptedPassword
+	) {
+
+	}
+
+	@Builder
+	record Result(
+		String accessToken,
+		String refreshToken
+	) {
+
+	}
+
+}

--- a/src/main/java/com/titi/titi_user/application/port/in/RegisterMemberUseCase.java
+++ b/src/main/java/com/titi/titi_user/application/port/in/RegisterMemberUseCase.java
@@ -1,79 +1,29 @@
 package com.titi.titi_user.application.port.in;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.List;
-import java.util.regex.Pattern;
-
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
 
-import com.titi.exception.TiTiErrorCodes;
-import com.titi.exception.TiTiException;
-import com.titi.titi_common_lib.dto.ErrorResponse;
-import com.titi.titi_crypto_lib.constant.AESCipherModes;
-import com.titi.titi_crypto_lib.exception.TiTiCryptoException;
-import com.titi.titi_crypto_lib.util.AESUtils;
 import com.titi.titi_crypto_lib.util.HashingUtils;
 import com.titi.titi_user.common.TiTiUserBusinessCodes;
 import com.titi.titi_user.common.TiTiUserException;
+import com.titi.titi_user.domain.member.EncodedEncryptedPassword;
 
 public interface RegisterMemberUseCase {
 
 	void invoke(Command command);
 
-	@Slf4j
 	@Builder
 	record Command(
 		String username,
-		String encodedEncryptedPassword,
+		EncodedEncryptedPassword encodedEncryptedPassword,
 		String nickname,
 		String authToken
 	) {
 
-		private static final String RAW_PASSWORD_REGEX = "^(?=.*\\d)(?=.*[a-zA-Z])(?=.*[~!@#$%^&()])[A-Za-z\\d~!@#$%^&()]{10,20}$";
-		private static final Pattern PATTERN = Pattern.compile(RAW_PASSWORD_REGEX);
 		private static final String AUTH_KEY_PREFIX = "ac_SU_E";
-
-		public String getRawPassword(byte[] wrappingKey) {
-			final byte[] encryptedPassword = this.decodePassword();
-			return this.decryptPassword(wrappingKey, encryptedPassword);
-		}
 
 		public void validateAuthKey(String authKey) {
 			if (!authKey.equals(HashingUtils.hashSha256(AUTH_KEY_PREFIX, this.username))) {
 				throw new TiTiUserException(TiTiUserBusinessCodes.AUTH_KEY_MISMATCHED_REGISTRATION_INFORMATION);
-			}
-		}
-
-		private String decryptPassword(byte[] wrappingKey, byte[] encryptedPassword) {
-			try {
-				final String rawPassword = new String(AESUtils.decrypt(wrappingKey, encryptedPassword, AESCipherModes.GCM_NO_PADDING), StandardCharsets.UTF_8);
-				this.validateRawPasswordPattern(rawPassword);
-				return rawPassword;
-			} catch (TiTiCryptoException e) {
-				log.error("Decrypt the encodedEncryptedPassword failed. ", e);
-				final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of("encodedEncryptedPassword", this.encodedEncryptedPassword, "Unwrapping the encodedEncryptedPassword failed.");
-				throw new TiTiException(TiTiErrorCodes.INPUT_TYPE_INVALID, errors);
-			}
-		}
-
-		private byte[] decodePassword() {
-			try {
-				return Base64.getUrlDecoder().decode(this.encodedEncryptedPassword);
-			} catch (IllegalArgumentException e) {
-				log.error("Base64url decoding the encodedEncryptedPassword failed. ", e);
-				final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of("encodedEncryptedPassword", this.encodedEncryptedPassword,
-					"Base64url decoding the encodedEncryptedPassword failed.");
-				throw new TiTiException(TiTiErrorCodes.INPUT_TYPE_INVALID, errors);
-			}
-		}
-
-		private void validateRawPasswordPattern(String rawPassword) {
-			if (!PATTERN.matcher(rawPassword).matches()) {
-				final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of("encodedEncryptedPassword", this.encodedEncryptedPassword,
-					"The rawPassword before being encrypted into encodedEncryptedPassword must match " + RAW_PASSWORD_REGEX);
-				throw new TiTiException(TiTiErrorCodes.INPUT_TYPE_INVALID, errors);
 			}
 		}
 

--- a/src/main/java/com/titi/titi_user/application/service/LoginService.java
+++ b/src/main/java/com/titi/titi_user/application/service/LoginService.java
@@ -1,0 +1,76 @@
+package com.titi.titi_user.application.service;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.titi.titi_common_lib.util.JwtUtils;
+import com.titi.titi_user.application.common.constant.UserConstants;
+import com.titi.titi_user.application.port.in.LoginUseCase;
+import com.titi.titi_user.application.port.out.persistence.FindMemberPort;
+import com.titi.titi_user.common.TiTiUserBusinessCodes;
+import com.titi.titi_user.common.TiTiUserException;
+import com.titi.titi_user.domain.member.Member;
+
+@Service
+@RequiredArgsConstructor
+class LoginService implements LoginUseCase {
+
+	private final FindMemberPort findMemberPort;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtUtils jwtUtils;
+	@Value("${crypto.secret-key}")
+	private String secretKey;
+
+	@Override
+	public Result invoke(Command command) {
+		final Member member = this.findMemberPort.invoke(Member.builder().username(command.username()).build())
+			.orElseThrow(() -> new TiTiUserException(TiTiUserBusinessCodes.LOGIN_FAILURE_MISMATCHED_MEMBER_INFORMATION));
+		final String rawPassword = command.encodedEncryptedPassword().getRawPassword(this.secretKey.getBytes());
+		this.validatePassword(rawPassword, member);
+		final Instant now = Instant.now();
+		return Result.builder()
+			.accessToken(this.generateAccessToken(member, now))
+			.refreshToken(this.generateRefreshToken(member, now))
+			.build();
+	}
+
+	private void validatePassword(String rawPassword, Member member) {
+		if (!this.passwordEncoder.matches(rawPassword, member.password())) {
+			throw new TiTiUserException(TiTiUserBusinessCodes.LOGIN_FAILURE_MISMATCHED_MEMBER_INFORMATION);
+		}
+	}
+
+	private String generateAccessToken(Member member, Instant now) {
+		return this.generateJWT(member.id().toString(), Date.from(now), Date.from(now.plusSeconds(UserConstants.ACCESS_TOKEN_EXPIRATION_TIME)), UserConstants.ACCESS_TOKEN);
+	}
+
+	private String generateRefreshToken(Member member, Instant now) {
+		return this.generateJWT(member.id().toString(), Date.from(now), Date.from(now.plusSeconds(UserConstants.REFRESH_TOKEN_EXPIRATION_TIME)), UserConstants.REFRESH_TOKEN);
+	}
+
+	private String generateJWT(String subject, Date now, Date expirationTime, String type) {
+		return this.jwtUtils.generate(
+			JwtUtils.Payload.builder()
+				.registeredClaim(
+					JwtUtils.Payload.RegisteredClaim.builder()
+						.issuer(UserConstants.JWT_ISSUER)
+						.subject(subject)
+						.expirationTime(expirationTime)
+						.issuedAt(now)
+						.jwtId(UUID.randomUUID().toString())
+						.build()
+				)
+				.additionalClaims(Map.of(JwtUtils.Payload.TYPE, type))
+				.build()
+		);
+	}
+
+}

--- a/src/main/java/com/titi/titi_user/application/service/RegisterMemberService.java
+++ b/src/main/java/com/titi/titi_user/application/service/RegisterMemberService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 
 import com.titi.titi_common_lib.util.JwtUtils;
+import com.titi.titi_user.application.common.constant.UserConstants;
 import com.titi.titi_user.application.port.in.RegisterMemberUseCase;
 import com.titi.titi_user.application.port.out.persistence.FindMemberPort;
 import com.titi.titi_user.application.port.out.persistence.SaveMemberPort;
@@ -58,7 +59,7 @@ class RegisterMemberService implements RegisterMemberUseCase {
 
 	private void validateAuthToken(Command command) {
 		try {
-			final String authKey = this.jwtUtils.getPayloads(command.authToken()).getSubject();
+			final String authKey = this.jwtUtils.getPayloads(command.authToken(), UserConstants.AUTH_TOKEN).getSubject();
 			command.validateAuthKey(authKey);
 		} catch (IllegalArgumentException e) {
 			throw new TiTiUserException(TiTiUserBusinessCodes.REGISTER_MEMBER_FAILURE_INVALID_AUTH_TOKEN);

--- a/src/main/java/com/titi/titi_user/application/service/RegisterMemberService.java
+++ b/src/main/java/com/titi/titi_user/application/service/RegisterMemberService.java
@@ -35,7 +35,7 @@ class RegisterMemberService implements RegisterMemberUseCase {
 	public void invoke(Command command) {
 		this.validateAuthToken(command);
 		this.validateUsername(command.username());
-		final String rawPassword = command.getRawPassword(this.secretKey.getBytes(StandardCharsets.UTF_8));
+		final String rawPassword = command.encodedEncryptedPassword().getRawPassword(this.secretKey.getBytes(StandardCharsets.UTF_8));
 		final String encryptedPassword = this.passwordEncoder.encode(rawPassword);
 		final Member member = Member.builder()
 			.username(command.username())

--- a/src/main/java/com/titi/titi_user/common/TiTiUserBusinessCodes.java
+++ b/src/main/java/com/titi/titi_user/common/TiTiUserBusinessCodes.java
@@ -12,6 +12,8 @@ public enum TiTiUserBusinessCodes {
 	REGISTER_MEMBER_SUCCESS(200, "USR1002", "Successfully completed the regular membership registration."),
 	REGISTER_MEMBER_FAILURE_INVALID_AUTH_TOKEN(200, "USR1003", "The registration has failed due to an invalid Auth Token."),
 	REGISTER_MEMBER_FAILURE_ALREADY_EXISTS_USERNAME(200, "USR1004", "The registration has failed as the username already exists."),
+	LOGIN_SUCCESS(200, "USR1005", "You have successfully logged in"),
+	LOGIN_FAILURE_MISMATCHED_MEMBER_INFORMATION(200, "USR1006", "Login failed due to mismatched member information."),
 
 	AUTH_KEY_MISMATCHED_REGISTRATION_INFORMATION(400, "USR7000", "The authentication key does not match the registration information."),
 	;

--- a/src/main/java/com/titi/titi_user/domain/member/EncodedEncryptedPassword.java
+++ b/src/main/java/com/titi/titi_user/domain/member/EncodedEncryptedPassword.java
@@ -1,0 +1,63 @@
+package com.titi.titi_user.domain.member;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+import com.titi.exception.TiTiErrorCodes;
+import com.titi.exception.TiTiException;
+import com.titi.titi_common_lib.dto.ErrorResponse;
+import com.titi.titi_crypto_lib.constant.AESCipherModes;
+import com.titi.titi_crypto_lib.exception.TiTiCryptoException;
+import com.titi.titi_crypto_lib.util.AESUtils;
+
+@Slf4j
+@Builder
+public record EncodedEncryptedPassword(
+	String value
+) {
+
+	private static final String RAW_PASSWORD_REGEX = "^(?=.*\\d)(?=.*[a-zA-Z])(?=.*[~!@#$%^&()])[A-Za-z\\d~!@#$%^&()]{10,20}$";
+	private static final Pattern PATTERN = Pattern.compile(RAW_PASSWORD_REGEX);
+
+	public String getRawPassword(byte[] secretKey) {
+		final byte[] encryptedPassword = this.decodePassword();
+		return this.decryptPassword(secretKey, encryptedPassword);
+	}
+
+	private String decryptPassword(byte[] secretKey, byte[] encryptedPassword) {
+		try {
+			final String rawPassword = new String(AESUtils.decrypt(secretKey, encryptedPassword, AESCipherModes.GCM_NO_PADDING), StandardCharsets.UTF_8);
+			this.validateRawPasswordPattern(rawPassword);
+			return rawPassword;
+		} catch (TiTiCryptoException e) {
+			log.error("Decrypt the encodedEncryptedPassword failed. ", e);
+			final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of("encodedEncryptedPassword", this.value, "Decrypt the encodedEncryptedPassword failed.");
+			throw new TiTiException(TiTiErrorCodes.INPUT_TYPE_INVALID, errors);
+		}
+	}
+
+	private byte[] decodePassword() {
+		try {
+			return Base64.getUrlDecoder().decode(this.value);
+		} catch (IllegalArgumentException e) {
+			log.error("Base64url decoding the encodedEncryptedPassword failed. ", e);
+			final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of("encodedEncryptedPassword", this.value,
+				"Base64url decoding the encodedEncryptedPassword failed.");
+			throw new TiTiException(TiTiErrorCodes.INPUT_TYPE_INVALID, errors);
+		}
+	}
+
+	private void validateRawPasswordPattern(String rawPassword) {
+		if (!PATTERN.matcher(rawPassword).matches()) {
+			final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of("encodedEncryptedPassword", this.value,
+				"The rawPassword before being encrypted into encodedEncryptedPassword must match " + RAW_PASSWORD_REGEX);
+			throw new TiTiException(TiTiErrorCodes.INPUT_TYPE_INVALID, errors);
+		}
+	}
+
+}

--- a/src/main/java/com/titi/titi_user/domain/member/ProfileImage.java
+++ b/src/main/java/com/titi/titi_user/domain/member/ProfileImage.java
@@ -1,5 +1,7 @@
 package com.titi.titi_user.domain.member;
 
+import java.util.UUID;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
@@ -33,7 +35,7 @@ public class ProfileImage {
 		// TODO implement
 		return ProfileImage.builder()
 			.profileImageName("name")
-			.profileImageId("id")
+			.profileImageId(UUID.randomUUID().toString())
 			.profileImageType(ProfileImageType.PNG)
 			.build();
 	}

--- a/src/test/java/com/titi/titi_common_lib/util/JwtUtilsTest.java
+++ b/src/test/java/com/titi/titi_common_lib/util/JwtUtilsTest.java
@@ -17,8 +17,7 @@ import io.jsonwebtoken.security.Keys;
 
 class JwtUtilsTest {
 
-	private final static String CLAIM_KEY = "testKey";
-	private final static String CLAIM_VALUE = "testValue";
+	private final static String TEST_TOKEN = "testToken";
 	private final static String ISSUER = "issuer";
 	private final static String SUBJECT = "subject";
 	private final static String JWT_ID = "jwtId";
@@ -36,11 +35,11 @@ class JwtUtilsTest {
 				.jwtId(JWT_ID)
 				.build()
 		)
-		.additionalClaims(Map.of(CLAIM_KEY, CLAIM_VALUE))
+		.additionalClaims(Map.of(JwtUtils.Payload.TYPE, TEST_TOKEN))
 		.build();
 	private final static String SECRET_KEY = "abcdefghijklmnopqrstuwxzy0123456";
 	private static final JwtBuilder JWT_BUILDER = Jwts.builder()
-		.claim(CLAIM_KEY, CLAIM_VALUE)
+		.claim(JwtUtils.Payload.TYPE, TEST_TOKEN)
 		.issuer(ISSUER)
 		.subject(SUBJECT)
 		.issuedAt(ISSUED_DATE)
@@ -51,13 +50,13 @@ class JwtUtilsTest {
 	@Test
 	void generateAndGetPayLoadsScenario() {
 		final String jwt = jwtUtils.generate(PAYLOAD);
-		final Claims claims = jwtUtils.getPayloads(jwt);
+		final Claims claims = jwtUtils.getPayloads(jwt, TEST_TOKEN);
 		assertThat(claims.getIssuer()).isEqualTo(ISSUER);
 		assertThat(claims.getSubject()).isEqualTo(SUBJECT);
 		assertThat(claims.getExpiration()).isEqualTo(EXPIRATION_DATE);
 		assertThat(claims.getIssuedAt()).isEqualTo(ISSUED_DATE);
 		assertThat(claims.getId()).isEqualTo(JWT_ID);
-		assertThat(claims.get(CLAIM_KEY)).isEqualTo(CLAIM_VALUE);
+		assertThat(claims.get(JwtUtils.Payload.TYPE)).isEqualTo(TEST_TOKEN);
 	}
 
 	@Nested
@@ -75,12 +74,12 @@ class JwtUtilsTest {
 
 		@Test
 		void givenValidJwtThenSuccessful() {
-			assertThat(jwtUtils.getPayloads(JWT_BUILDER.expiration(EXPIRATION_DATE).compact()).get(CLAIM_KEY)).isEqualTo(CLAIM_VALUE);
+			assertThat(jwtUtils.getPayloads(JWT_BUILDER.expiration(EXPIRATION_DATE).compact(), TEST_TOKEN).get(JwtUtils.Payload.TYPE)).isEqualTo(TEST_TOKEN);
 		}
 
 		@Test
 		void givenExpiredJwtThenThrowIllegalArgumentException() {
-			assertThatCode(() -> jwtUtils.getPayloads(JWT_BUILDER.expiration(EXPIRED_DATE).compact())).isInstanceOf(IllegalArgumentException.class);
+			assertThatCode(() -> jwtUtils.getPayloads(JWT_BUILDER.expiration(EXPIRED_DATE).compact(), TEST_TOKEN)).isInstanceOf(IllegalArgumentException.class);
 		}
 
 	}

--- a/src/test/java/com/titi/titi_user/adapter/in/web/api/LoginControllerTest.java
+++ b/src/test/java/com/titi/titi_user/adapter/in/web/api/LoginControllerTest.java
@@ -1,0 +1,86 @@
+package com.titi.titi_user.adapter.in.web.api;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.titi.titi_common_lib.util.JacksonHelper;
+import com.titi.titi_user.adapter.in.web.api.LoginController.LoginRequestBody;
+import com.titi.titi_user.application.port.in.LoginUseCase;
+import com.titi.titi_user.common.TiTiUserBusinessCodes;
+import com.titi.titi_user.common.TiTiUserException;
+
+@WebMvcTest(controllers = LoginController.class)
+class LoginControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private LoginUseCase loginUseCase;
+
+	private static LoginRequestBody getLoginRequestBody() {
+		return LoginRequestBody.builder()
+			.username("test@gmail.com")
+			.encodedEncryptedPassword("encodedEncryptedPassword")
+			.build();
+	}
+
+	private ResultActions mockRegisterMember(LoginRequestBody requestBody) throws Exception {
+		return mockMvc.perform(post("/api/user/members/login")
+			.content(JacksonHelper.toJson(requestBody))
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.with(csrf()));
+	}
+
+	@Test
+	@WithMockUser
+	void whenSuccessToLoginThenCodeIsUSR1005() throws Exception {
+		// given
+		given(loginUseCase.invoke(any(LoginUseCase.Command.class))).willReturn(
+			LoginUseCase.Result.builder()
+				.accessToken("accessToken")
+				.refreshToken("refreshToken")
+				.build()
+		);
+
+		// when
+		final ResultActions perform = mockRegisterMember(getLoginRequestBody());
+
+		// then
+		perform.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(TiTiUserBusinessCodes.LOGIN_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.message").value(TiTiUserBusinessCodes.LOGIN_SUCCESS.getMessage()))
+			.andExpect(jsonPath("$.access_token").isNotEmpty())
+			.andExpect(jsonPath("$.refresh_token").isNotEmpty());
+		verify(loginUseCase, times(1)).invoke(any(LoginUseCase.Command.class));
+	}
+
+	@Test
+	@WithMockUser
+	void whenFailureToLoginThenCodeIsUSR1006() throws Exception {
+		// given
+		given(loginUseCase.invoke(any(LoginUseCase.Command.class))).willThrow(new TiTiUserException(TiTiUserBusinessCodes.LOGIN_FAILURE_MISMATCHED_MEMBER_INFORMATION));
+
+		// when
+		final ResultActions perform = mockRegisterMember(getLoginRequestBody());
+
+		// then
+		perform.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(TiTiUserBusinessCodes.LOGIN_FAILURE_MISMATCHED_MEMBER_INFORMATION.getCode()))
+			.andExpect(jsonPath("$.message").value(TiTiUserBusinessCodes.LOGIN_FAILURE_MISMATCHED_MEMBER_INFORMATION.getMessage()));
+		verify(loginUseCase, times(1)).invoke(any(LoginUseCase.Command.class));
+	}
+
+}

--- a/src/test/java/com/titi/titi_user/application/port/in/RegisterMemberUseCaseTest.java
+++ b/src/test/java/com/titi/titi_user/application/port/in/RegisterMemberUseCaseTest.java
@@ -2,7 +2,6 @@ package com.titi.titi_user.application.port.in;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.util.Base64;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.ThrowableAssert;
@@ -12,89 +11,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import com.titi.exception.TiTiException;
-import com.titi.titi_crypto_lib.constant.AESCipherModes;
-import com.titi.titi_crypto_lib.util.AESUtils;
 import com.titi.titi_crypto_lib.util.HashingUtils;
 import com.titi.titi_user.common.TiTiUserException;
 
 class RegisterMemberUseCaseTest {
-
-	@Nested
-	class GetRawPassword {
-
-		private static final byte[] WRAPPING_KEY = "803984986d8211443170c42a37d33d61".getBytes();
-
-		@Test
-		void successfulScenario() {
-			// given
-			final String rawPassword = "qlalfqjsgh1!";
-			final byte[] encryptedPassword = AESUtils.encrypt(WRAPPING_KEY, rawPassword.getBytes(), AESCipherModes.GCM_NO_PADDING);
-			final String encodedEncryptedPassword = Base64.getUrlEncoder().encodeToString(encryptedPassword);
-			
-			final RegisterMemberUseCase.Command command = RegisterMemberUseCase.Command.builder()
-				.encodedEncryptedPassword(encodedEncryptedPassword)
-				.build();
-
-			// when
-			final String unwrapPassword = command.getRawPassword(WRAPPING_KEY);
-
-			// then
-			assertThat(rawPassword).isEqualTo(unwrapPassword);
-		}
-
-		@Test
-		void failToDecodeBase64urlScenario() {
-			// given
-			final String rawPassword = "qlalfqjsgh1!";
-
-			final RegisterMemberUseCase.Command command = RegisterMemberUseCase.Command.builder()
-				.encodedEncryptedPassword(rawPassword)
-				.build();
-
-			// when
-			final ThrowableAssert.ThrowingCallable throwingCallable = () -> command.getRawPassword(WRAPPING_KEY);
-
-			// then
-			assertThatCode(throwingCallable).isInstanceOf(TiTiException.class);
-		}
-
-		@Test
-		void failToDecryptAES256Scenario() {
-			// given
-			final String rawPassword = "qlalfqjsgh1!";
-			final String encodedPassword = Base64.getUrlEncoder().encodeToString(rawPassword.getBytes());
-
-			final RegisterMemberUseCase.Command command = RegisterMemberUseCase.Command.builder()
-				.encodedEncryptedPassword(encodedPassword)
-				.build();
-
-			// when
-			final ThrowableAssert.ThrowingCallable throwingCallable = () -> command.getRawPassword(WRAPPING_KEY);
-
-			// then
-			assertThatCode(throwingCallable).isInstanceOf(TiTiException.class);
-		}
-
-		@Test
-		void failToMisMatchedPatternScenario() {
-			// given
-			final String rawPassword = "qlalfqjsgh";
-			final byte[] encryptedPassword = AESUtils.encrypt(WRAPPING_KEY, rawPassword.getBytes(), AESCipherModes.GCM_NO_PADDING);
-			final String encodedEncryptedPassword = Base64.getUrlEncoder().encodeToString(encryptedPassword);
-
-			final RegisterMemberUseCase.Command command = RegisterMemberUseCase.Command.builder()
-				.encodedEncryptedPassword(encodedEncryptedPassword)
-				.build();
-
-			// when
-			final ThrowableAssert.ThrowingCallable throwingCallable = () -> command.getRawPassword(WRAPPING_KEY);
-
-			// then
-			assertThatCode(throwingCallable).isInstanceOf(TiTiException.class);
-		}
-
-	}
 
 	@Nested
 	class ValidateAuthKey {

--- a/src/test/java/com/titi/titi_user/application/service/LoginServiceTest.java
+++ b/src/test/java/com/titi/titi_user/application/service/LoginServiceTest.java
@@ -1,0 +1,127 @@
+package com.titi.titi_user.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Base64;
+import java.util.Optional;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.titi.titi_common_lib.util.JwtUtils;
+import com.titi.titi_crypto_lib.constant.AESCipherModes;
+import com.titi.titi_crypto_lib.util.AESUtils;
+import com.titi.titi_user.application.port.in.LoginUseCase;
+import com.titi.titi_user.application.port.out.persistence.FindMemberPort;
+import com.titi.titi_user.common.TiTiUserException;
+import com.titi.titi_user.domain.member.EncodedEncryptedPassword;
+import com.titi.titi_user.domain.member.Member;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceTest {
+
+	private static final Long ID = 1L;
+	private static final String JWT = "jwt";
+	private static final String USERNAME = "test@gmail.com";
+	private static final String RAW_PASSWORD = "qlalfqjsgh1!";
+	private static final String BCRYPTED_PASSWORD = "bcryptedPassword";
+	private static final String SECRET_KEY = "12345678901234567890123456789012";
+	private static final byte[] ENCRYPTED_PASSWORD = AESUtils.encrypt(SECRET_KEY.getBytes(), RAW_PASSWORD.getBytes(), AESCipherModes.GCM_NO_PADDING);
+	private static final String ENCODED_ENCRYPTED_PASSWORD = Base64.getUrlEncoder().encodeToString(ENCRYPTED_PASSWORD);
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	@Mock
+	private JwtUtils jwtUtils;
+
+	@Mock
+	private FindMemberPort findMemberPort;
+
+	@InjectMocks
+	private LoginService loginService;
+
+	@BeforeEach
+	void setup() {
+		ReflectionTestUtils.setField(loginService, "secretKey", SECRET_KEY);
+	}
+
+	@Test
+	void successfulScenario() {
+		// given
+		final Member mockMember = mock(Member.class);
+		given(mockMember.id()).willReturn(ID);
+		given(mockMember.password()).willReturn(BCRYPTED_PASSWORD);
+		given(findMemberPort.invoke(any(Member.class))).willReturn(Optional.of(mockMember));
+		given(passwordEncoder.matches(RAW_PASSWORD, BCRYPTED_PASSWORD)).willReturn(true);
+		given(jwtUtils.generate(any(JwtUtils.Payload.class))).willReturn(JWT);
+
+		// when
+		final LoginUseCase.Result result = loginService.invoke(
+			LoginUseCase.Command.builder()
+				.username(USERNAME)
+				.encodedEncryptedPassword(EncodedEncryptedPassword.builder().value(ENCODED_ENCRYPTED_PASSWORD).build())
+				.build()
+		);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.accessToken()).isNotBlank();
+		assertThat(result.refreshToken()).isNotBlank();
+		verify(findMemberPort, times(1)).invoke(any(Member.class));
+		verify(passwordEncoder, times(1)).matches(RAW_PASSWORD, BCRYPTED_PASSWORD);
+		verify(jwtUtils, times(2)).generate(any(JwtUtils.Payload.class));
+	}
+
+	@Test
+	void failToFindMemberScenario() {
+		// given
+		given(findMemberPort.invoke(any(Member.class))).willReturn(Optional.empty());
+
+		// when
+		final ThrowableAssert.ThrowingCallable throwingCallable = () -> loginService.invoke(
+			LoginUseCase.Command.builder()
+				.username(USERNAME)
+				.encodedEncryptedPassword(EncodedEncryptedPassword.builder().value(ENCODED_ENCRYPTED_PASSWORD).build())
+				.build()
+		);
+
+		// then
+		assertThatCode(throwingCallable).isInstanceOf(TiTiUserException.class);
+		verify(findMemberPort, times(1)).invoke(any(Member.class));
+		verify(passwordEncoder, never()).matches(RAW_PASSWORD, BCRYPTED_PASSWORD);
+		verify(jwtUtils, never()).generate(any(JwtUtils.Payload.class));
+	}
+
+	@Test
+	void failToValidatePasswordScenario() {
+		// given
+		final Member mockMember = mock(Member.class);
+		given(mockMember.password()).willReturn(BCRYPTED_PASSWORD);
+		given(findMemberPort.invoke(any(Member.class))).willReturn(Optional.of(mockMember));
+		given(passwordEncoder.matches(RAW_PASSWORD, BCRYPTED_PASSWORD)).willReturn(false);
+
+		// when
+		final ThrowableAssert.ThrowingCallable throwingCallable = () -> loginService.invoke(
+			LoginUseCase.Command.builder()
+				.username(USERNAME)
+				.encodedEncryptedPassword(EncodedEncryptedPassword.builder().value(ENCODED_ENCRYPTED_PASSWORD).build())
+				.build()
+		);
+
+		// then
+		assertThatCode(throwingCallable).isInstanceOf(TiTiUserException.class);
+		verify(findMemberPort, times(1)).invoke(any(Member.class));
+		verify(passwordEncoder, times(1)).matches(RAW_PASSWORD, BCRYPTED_PASSWORD);
+		verify(jwtUtils, never()).generate(any(JwtUtils.Payload.class));
+	}
+
+}

--- a/src/test/java/com/titi/titi_user/application/service/RegisterMemberServiceTest.java
+++ b/src/test/java/com/titi/titi_user/application/service/RegisterMemberServiceTest.java
@@ -22,6 +22,7 @@ import com.titi.titi_common_lib.util.JwtUtils;
 import com.titi.titi_crypto_lib.constant.AESCipherModes;
 import com.titi.titi_crypto_lib.util.AESUtils;
 import com.titi.titi_crypto_lib.util.HashingUtils;
+import com.titi.titi_user.application.common.constant.UserConstants;
 import com.titi.titi_user.application.port.in.RegisterMemberUseCase;
 import com.titi.titi_user.application.port.out.persistence.FindMemberPort;
 import com.titi.titi_user.application.port.out.persistence.SaveMemberPort;
@@ -64,7 +65,7 @@ class RegisterMemberServiceTest {
 	@Test
 	void successfulScenario() {
 		// given
-		given(jwtUtils.getPayloads(MOCK_AUTH_TOKEN)).willReturn(MOCK_CLAIMS);
+		given(jwtUtils.getPayloads(MOCK_AUTH_TOKEN, UserConstants.AUTH_TOKEN)).willReturn(MOCK_CLAIMS);
 		given(MOCK_CLAIMS.getSubject()).willReturn(AUTH_KEY);
 		given(findMemberPort.invoke(any())).willReturn(Optional.empty());
 		given(passwordEncoder.encode(RAW_PASSWORD)).willReturn("encryptedPassword");
@@ -85,7 +86,7 @@ class RegisterMemberServiceTest {
 	@Test
 	void failToValidateUsernameScenario() {
 		// given
-		given(jwtUtils.getPayloads(MOCK_AUTH_TOKEN)).willReturn(MOCK_CLAIMS);
+		given(jwtUtils.getPayloads(MOCK_AUTH_TOKEN, UserConstants.AUTH_TOKEN)).willReturn(MOCK_CLAIMS);
 		given(MOCK_CLAIMS.getSubject()).willReturn(AUTH_KEY);
 		given(findMemberPort.invoke(any())).willReturn(Optional.of(mock(Member.class)));
 
@@ -105,7 +106,7 @@ class RegisterMemberServiceTest {
 	@Test
 	void failToValidateAuthTokenScenario() {
 		// given
-		given(jwtUtils.getPayloads(MOCK_AUTH_TOKEN)).willThrow(IllegalArgumentException.class);
+		given(jwtUtils.getPayloads(MOCK_AUTH_TOKEN, UserConstants.AUTH_TOKEN)).willThrow(IllegalArgumentException.class);
 
 		// when
 		final RegisterMemberUseCase.Command command = RegisterMemberUseCase.Command.builder()

--- a/src/test/java/com/titi/titi_user/application/service/RegisterMemberServiceTest.java
+++ b/src/test/java/com/titi/titi_user/application/service/RegisterMemberServiceTest.java
@@ -26,6 +26,7 @@ import com.titi.titi_user.application.port.in.RegisterMemberUseCase;
 import com.titi.titi_user.application.port.out.persistence.FindMemberPort;
 import com.titi.titi_user.application.port.out.persistence.SaveMemberPort;
 import com.titi.titi_user.common.TiTiUserException;
+import com.titi.titi_user.domain.member.EncodedEncryptedPassword;
 import com.titi.titi_user.domain.member.Member;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,9 +37,9 @@ class RegisterMemberServiceTest {
 	private static final String USERNAME = "test@gmail.com";
 	private static final String AUTH_KEY = HashingUtils.hashSha256("ac_SU_E", USERNAME);
 	private static final String RAW_PASSWORD = "qlalfqjsgh1!";
-	private static final String WRAPPING_KEY = "12345678901234567890123456789012";
-	private static final byte[] WRAPPED_PASSWORD = AESUtils.encrypt(WRAPPING_KEY.getBytes(), RAW_PASSWORD.getBytes(), AESCipherModes.GCM_NO_PADDING);
-	private static final String ENCODED_WRAPPED_PASSWORD = Base64.getUrlEncoder().encodeToString(WRAPPED_PASSWORD);
+	private static final String SECRET_KEY = "12345678901234567890123456789012";
+	private static final byte[] ENCRYPTED_PASSWORD = AESUtils.encrypt(SECRET_KEY.getBytes(), RAW_PASSWORD.getBytes(), AESCipherModes.GCM_NO_PADDING);
+	private static final String ENCODED_ENCRYPTED_PASSWORD = Base64.getUrlEncoder().encodeToString(ENCRYPTED_PASSWORD);
 
 	@Mock
 	private PasswordEncoder passwordEncoder;
@@ -57,7 +58,7 @@ class RegisterMemberServiceTest {
 
 	@BeforeEach
 	void setup() {
-		ReflectionTestUtils.setField(registerMemberService, "wrappingKey", WRAPPING_KEY);
+		ReflectionTestUtils.setField(registerMemberService, "secretKey", SECRET_KEY);
 	}
 
 	@Test
@@ -71,7 +72,7 @@ class RegisterMemberServiceTest {
 		// when
 		final RegisterMemberUseCase.Command command = RegisterMemberUseCase.Command.builder()
 			.username(USERNAME)
-			.encodedEncryptedPassword(ENCODED_WRAPPED_PASSWORD)
+			.encodedEncryptedPassword(EncodedEncryptedPassword.builder().value(ENCODED_ENCRYPTED_PASSWORD).build())
 			.nickname("nickname")
 			.authToken(MOCK_AUTH_TOKEN)
 			.build();
@@ -91,7 +92,7 @@ class RegisterMemberServiceTest {
 		// when
 		final RegisterMemberUseCase.Command command = RegisterMemberUseCase.Command.builder()
 			.username(USERNAME)
-			.encodedEncryptedPassword(ENCODED_WRAPPED_PASSWORD)
+			.encodedEncryptedPassword(EncodedEncryptedPassword.builder().value(ENCODED_ENCRYPTED_PASSWORD).build())
 			.nickname("nickname")
 			.authToken(MOCK_AUTH_TOKEN)
 			.build();
@@ -109,7 +110,7 @@ class RegisterMemberServiceTest {
 		// when
 		final RegisterMemberUseCase.Command command = RegisterMemberUseCase.Command.builder()
 			.username(USERNAME)
-			.encodedEncryptedPassword(ENCODED_WRAPPED_PASSWORD)
+			.encodedEncryptedPassword(EncodedEncryptedPassword.builder().value(ENCODED_ENCRYPTED_PASSWORD).build())
 			.nickname("nickname")
 			.authToken(MOCK_AUTH_TOKEN)
 			.build();

--- a/src/test/java/com/titi/titi_user/domain/member/EncodedEncryptedPasswordTest.java
+++ b/src/test/java/com/titi/titi_user/domain/member/EncodedEncryptedPasswordTest.java
@@ -1,0 +1,86 @@
+package com.titi.titi_user.domain.member;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Base64;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.titi.exception.TiTiException;
+import com.titi.titi_crypto_lib.constant.AESCipherModes;
+import com.titi.titi_crypto_lib.util.AESUtils;
+
+class EncodedEncryptedPasswordTest {
+
+	@Nested
+	class GetRawPassword {
+
+		private static final byte[] SECRET_KEY = "12345678901234567890123456789012".getBytes();
+
+		@Test
+		void successfulScenario() {
+			// given
+			final String rawPassword = "qlalfqjsgh1!";
+			final byte[] encryptedPassword = AESUtils.encrypt(SECRET_KEY, rawPassword.getBytes(), AESCipherModes.GCM_NO_PADDING);
+			final EncodedEncryptedPassword encodedEncryptedPassword = EncodedEncryptedPassword.builder()
+				.value(Base64.getUrlEncoder().encodeToString(encryptedPassword))
+				.build();
+
+			// when
+			final String result = encodedEncryptedPassword.getRawPassword(SECRET_KEY);
+
+			// then
+			assertThat(result).isEqualTo(rawPassword);
+		}
+
+		@Test
+		void failToDecodeBase64urlScenario() {
+			// given
+			final String rawPassword = "qlalfqjsgh1!";
+			final EncodedEncryptedPassword encodedEncryptedPassword = EncodedEncryptedPassword.builder()
+				.value(rawPassword)
+				.build();
+
+			// when
+			final ThrowableAssert.ThrowingCallable throwingCallable = () -> encodedEncryptedPassword.getRawPassword(SECRET_KEY);
+
+			// then
+			assertThatCode(throwingCallable).isInstanceOf(TiTiException.class);
+		}
+
+		@Test
+		void failToDecryptAES256Scenario() {
+			// given
+			final String rawPassword = "qlalfqjsgh1!";
+			final EncodedEncryptedPassword encodedEncryptedPassword = EncodedEncryptedPassword.builder()
+				.value(Base64.getUrlEncoder().encodeToString(rawPassword.getBytes()))
+				.build();
+
+			// when
+			final ThrowableAssert.ThrowingCallable throwingCallable = () -> encodedEncryptedPassword.getRawPassword(SECRET_KEY);
+
+			// then
+			assertThatCode(throwingCallable).isInstanceOf(TiTiException.class);
+		}
+
+		@Test
+		void failToMisMatchedPatternScenario() {
+			// given
+			final String rawPassword = "qlalfqjsgh";
+			final byte[] encryptedPassword = AESUtils.encrypt(SECRET_KEY, rawPassword.getBytes(), AESCipherModes.GCM_NO_PADDING);
+			final EncodedEncryptedPassword encodedEncryptedPassword = EncodedEncryptedPassword.builder()
+				.value(Base64.getUrlEncoder().encodeToString(encryptedPassword))
+				.build();
+
+			// when
+			final ThrowableAssert.ThrowingCallable throwingCallable = () -> encodedEncryptedPassword.getRawPassword(SECRET_KEY);
+
+			// then
+			assertThatCode(throwingCallable).isInstanceOf(TiTiException.class);
+		}
+
+	}
+
+}


### PR DESCRIPTION
## 🍋 개요
<!--
ex) Issue: Resolve #3
이슈 번호 앞에 Resolve를 붙이면, merge 시 자동으로 issue도 close됩니다.
-->
-  📌 Issue: Resolve #46 

## 🍊 변경 사항
- 일반 로그인 API를 개발했어요.
- profileImageId가 unique 속성이기 떄문에, ProfileImage의 defaultInstance() 메소드 내부에서 profileImageId에 random UUID 값을 주입하도록 수정했어요.
- EncodedEncryptedPassword 클래스를 추출했어요.
- JWT 목적에 따른 사용을 검증하기 위해, type claim을 추가했어요.

## 🥨 참고 사항


## 🍏 체크리스트
- [x] 변경된 파일마다 코드 정렬(`CTRL` + `ALT` + `L`)은 완료하였나요?
- [x] 설계된 내용대로 `구현`을 모두 완료하였나요?
- [x] 변경 사항에 대한 `Test Code`는 모두 작성하였나요?
- [x] `Commit Message`는 충분히 자세하게 작성되었나요?
- [x] `Assignees`, `Label`은 적용하였나요?