### PR TITLE
Access Token 재발급 API 개발

### DIFF
--- a/src/main/java/com/titi/titi_auth/adapter/in/internal/GenerateAccessTokenGateway.java
+++ b/src/main/java/com/titi/titi_auth/adapter/in/internal/GenerateAccessTokenGateway.java
@@ -1,0 +1,42 @@
+package com.titi.titi_auth.adapter.in.internal;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+import com.titi.titi_auth.adapter.in.internal.mapper.AuthInternalMapper;
+import com.titi.titi_auth.application.port.in.GenerateAccessTokenUseCase;
+
+@Validated
+@Component
+@RequiredArgsConstructor
+public class GenerateAccessTokenGateway {
+
+	private final GenerateAccessTokenUseCase generateAccessTokenUseCase;
+
+	public GenerateAccessTokenResponse invoke(@Valid GenerateAccessTokenRequest request) {
+		final GenerateAccessTokenUseCase.Result result = this.generateAccessTokenUseCase.invoke(AuthInternalMapper.INSTANCE.toCommand(request));
+		return AuthInternalMapper.INSTANCE.toResponse(result);
+	}
+
+	@Builder
+	public record GenerateAccessTokenRequest(
+		@NotBlank String memberId,
+		@NotBlank String deviceId
+	) {
+
+	}
+
+	@Builder
+	public record GenerateAccessTokenResponse(
+		String accessToken,
+		String refreshToken
+	) {
+
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/adapter/in/internal/mapper/AuthInternalMapper.java
+++ b/src/main/java/com/titi/titi_auth/adapter/in/internal/mapper/AuthInternalMapper.java
@@ -1,0 +1,18 @@
+package com.titi.titi_auth.adapter.in.internal.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import com.titi.titi_auth.adapter.in.internal.GenerateAccessTokenGateway;
+import com.titi.titi_auth.application.port.in.GenerateAccessTokenUseCase;
+
+@Mapper
+public interface AuthInternalMapper {
+
+	AuthInternalMapper INSTANCE = Mappers.getMapper(AuthInternalMapper.class);
+
+	GenerateAccessTokenUseCase.Command toCommand(GenerateAccessTokenGateway.GenerateAccessTokenRequest request);
+
+	GenerateAccessTokenGateway.GenerateAccessTokenResponse toResponse(GenerateAccessTokenUseCase.Result result);
+
+}

--- a/src/main/java/com/titi/titi_auth/adapter/in/web/api/ReissueAccessTokenController.java
+++ b/src/main/java/com/titi/titi_auth/adapter/in/web/api/ReissueAccessTokenController.java
@@ -1,0 +1,76 @@
+package com.titi.titi_auth.adapter.in.web.api;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+import com.titi.titi_auth.application.port.in.ReissueAccessTokenUseCase;
+import com.titi.titi_auth.common.TiTiAuthBusinessCodes;
+
+@RestController
+@RequiredArgsConstructor
+class ReissueAccessTokenController implements AuthApi {
+
+	private final ReissueAccessTokenUseCase reissueAccessTokenUseCase;
+
+	@Operation(summary = "Reissue access token API", description = "Reissue the Access Token.")
+	@PostMapping(value = "/token/reissue", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<ReissueAccessTokenResponseBody> reissueAccessToken(@Valid @RequestBody ReissueAccessTokenRequestBody requestBody) {
+		final ReissueAccessTokenUseCase.Result result = this.reissueAccessTokenUseCase.invoke(
+			ReissueAccessTokenUseCase.Command.builder()
+				.refreshToken(requestBody.refreshToken())
+				.build()
+		);
+		return ResponseEntity.status(TiTiAuthBusinessCodes.REISSUE_ACCESS_TOKEN_SUCCESS.getStatus())
+			.body(
+				ReissueAccessTokenResponseBody.builder()
+					.code(TiTiAuthBusinessCodes.REISSUE_ACCESS_TOKEN_SUCCESS.getCode())
+					.message(TiTiAuthBusinessCodes.REISSUE_ACCESS_TOKEN_SUCCESS.getMessage())
+					.accessToken(result.accessToken())
+					.refreshToken(result.refreshToken())
+					.build()
+			);
+	}
+
+	@Builder
+	@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+	public record ReissueAccessTokenRequestBody(
+		@Schema(
+			description = "Refresh Token for reissuing the Access Token (Validity : 2 weeks)",
+			requiredMode = Schema.RequiredMode.REQUIRED
+		) @NotBlank String refreshToken
+	) {
+
+	}
+
+	@Builder
+	@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+	public record ReissueAccessTokenResponseBody(
+		@Schema(
+			description = "TiTi Business code."
+		) String code,
+		@Schema(
+			description = "API result message."
+		) String message,
+		@Schema(
+			description = "Access Token for self-authentication (Validity : 30 minutes)"
+		) String accessToken,
+		@Schema(
+			description = "Refresh Token for reissuing the Access Token (Validity : 2 weeks)"
+		) String refreshToken
+	) {
+
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/adapter/out/cache/AuthCacheKeys.java
+++ b/src/main/java/com/titi/titi_auth/adapter/out/cache/AuthCacheKeys.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AuthCacheKeys {
-	AUTH_CODE("ac", 5 * 60 * SECONDS);
+	AUTH_CODE("ac", 5 * 60 * SECONDS),
+	REFRESH_TOKEN("rt", 14 * 24 * 60 * 60 * SECONDS);
 
 	private final String prefix;
 	private final long timeToLive;

--- a/src/main/java/com/titi/titi_auth/adapter/out/cache/GetRefreshTokenPortAdapter.java
+++ b/src/main/java/com/titi/titi_auth/adapter/out/cache/GetRefreshTokenPortAdapter.java
@@ -1,0 +1,38 @@
+package com.titi.titi_auth.adapter.out.cache;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.titi.infrastructure.cache.CacheManager;
+import com.titi.titi_auth.application.port.out.cache.GetRefreshTokenPort;
+import com.titi.titi_auth.common.TiTiAuthBusinessCodes;
+import com.titi.titi_auth.common.TiTiAuthException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class GetRefreshTokenPortAdapter implements GetRefreshTokenPort {
+
+	private final CacheManager cacheManager;
+
+	@Override
+	public Result invoke(Command command) {
+		final String key = command.generateCacheKey();
+		try {
+			final Optional<String> refreshTokenOptional = this.cacheManager.get(key);
+			refreshTokenOptional.ifPresentOrElse(
+				refreshToken -> log.info("Successfully got the refreshToken from the cache. key: {} refreshToken: {}", key, refreshToken),
+				() -> log.info("Failed to get the refreshToken from the cache. This may be due to the expiration of the refreshToken or the invalidity of the key. key: {}", key)
+			);
+			return GetRefreshTokenPort.Result.builder().refreshToken(refreshTokenOptional).build();
+		} catch (Exception e) {
+			log.error("Failed to get the refreshToken from the cache. key: {} ", key, e);
+			throw new TiTiAuthException(TiTiAuthBusinessCodes.CACHE_SERVER_ERROR);
+		}
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/adapter/out/cache/PutRefreshTokenPortAdapter.java
+++ b/src/main/java/com/titi/titi_auth/adapter/out/cache/PutRefreshTokenPortAdapter.java
@@ -1,0 +1,32 @@
+package com.titi.titi_auth.adapter.out.cache;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.titi.infrastructure.cache.CacheManager;
+import com.titi.titi_auth.application.port.out.cache.PutRefreshTokenPort;
+import com.titi.titi_auth.common.TiTiAuthBusinessCodes;
+import com.titi.titi_auth.common.TiTiAuthException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PutRefreshTokenPortAdapter implements PutRefreshTokenPort {
+
+	private final CacheManager cacheManager;
+
+	@Override
+	public void invoke(Command command) {
+		final String key = command.generateCacheKey();
+		try {
+			this.cacheManager.put(key, command.refreshToken(), AuthCacheKeys.REFRESH_TOKEN.getTimeToLive());
+			log.info("Successfully put refreshToken in cache. key: {}.", key);
+		} catch (Exception e) {
+			log.error("Failed to put refreshToken in cache. key: {}.", key, e);
+			throw new TiTiAuthException(TiTiAuthBusinessCodes.CACHE_SERVER_ERROR);
+		}
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/application/common/constant/AuthConstants.java
+++ b/src/main/java/com/titi/titi_auth/application/common/constant/AuthConstants.java
@@ -1,5 +1,7 @@
 package com.titi.titi_auth.application.common.constant;
 
+import static com.titi.titi_common_lib.constant.Constants.*;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -9,5 +11,15 @@ public final class AuthConstants {
 	public static final String SERVICE_NAME = "AUTH";
 	public static final String JWT_ISSUER = "TiTi-Auth";
 	public static final String AUTH_TOKEN = "authToken";
+	public static final String ACCESS_TOKEN = "accessToken";
+	public static final String REFRESH_TOKEN = "refreshToken";
+	/**
+	 * 30 minutes
+	 */
+	public static final int ACCESS_TOKEN_EXPIRATION_TIME = 30 * 60 * SECONDS;
+	/**
+	 * 2 weeks
+	 */
+	public static final int REFRESH_TOKEN_EXPIRATION_TIME = 14 * 24 * 60 * 60 * SECONDS;
 
 }

--- a/src/main/java/com/titi/titi_auth/application/port/in/GenerateAccessTokenUseCase.java
+++ b/src/main/java/com/titi/titi_auth/application/port/in/GenerateAccessTokenUseCase.java
@@ -1,0 +1,25 @@
+package com.titi.titi_auth.application.port.in;
+
+import lombok.Builder;
+
+public interface GenerateAccessTokenUseCase {
+
+	Result invoke(Command command);
+
+	@Builder
+	record Command(
+		String memberId,
+		String deviceId
+	) {
+
+	}
+
+	@Builder
+	record Result(
+		String accessToken,
+		String refreshToken
+	) {
+
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/application/port/in/ReissueAccessTokenUseCase.java
+++ b/src/main/java/com/titi/titi_auth/application/port/in/ReissueAccessTokenUseCase.java
@@ -1,0 +1,24 @@
+package com.titi.titi_auth.application.port.in;
+
+import lombok.Builder;
+
+public interface ReissueAccessTokenUseCase {
+
+	Result invoke(Command command);
+
+	@Builder
+	record Command(
+		String refreshToken
+	) {
+
+	}
+
+	@Builder
+	record Result(
+		String accessToken,
+		String refreshToken
+	) {
+
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/application/port/out/cache/GetRefreshTokenPort.java
+++ b/src/main/java/com/titi/titi_auth/application/port/out/cache/GetRefreshTokenPort.java
@@ -1,0 +1,31 @@
+package com.titi.titi_auth.application.port.out.cache;
+
+import java.util.Optional;
+
+import lombok.Builder;
+
+import com.titi.titi_auth.adapter.out.cache.AuthCacheKeys;
+
+public interface GetRefreshTokenPort {
+
+	Result invoke(Command command);
+
+	@Builder
+	record Command(
+		String subject
+	) {
+
+		public String generateCacheKey() {
+			return AuthCacheKeys.REFRESH_TOKEN.getPrefix() + this.subject;
+		}
+
+	}
+
+	@Builder
+	record Result(
+		Optional<String> refreshToken
+	) {
+
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/application/port/out/cache/PutRefreshTokenPort.java
+++ b/src/main/java/com/titi/titi_auth/application/port/out/cache/PutRefreshTokenPort.java
@@ -1,0 +1,23 @@
+package com.titi.titi_auth.application.port.out.cache;
+
+import lombok.Builder;
+
+import com.titi.titi_auth.adapter.out.cache.AuthCacheKeys;
+
+public interface PutRefreshTokenPort {
+
+	void invoke(Command command);
+
+	@Builder
+	record Command(
+		String subject,
+		String refreshToken
+	) {
+
+		public String generateCacheKey() {
+			return AuthCacheKeys.REFRESH_TOKEN.getPrefix() + this.subject;
+		}
+
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/application/service/GenerateAccessTokenService.java
+++ b/src/main/java/com/titi/titi_auth/application/service/GenerateAccessTokenService.java
@@ -1,0 +1,40 @@
+package com.titi.titi_auth.application.service;
+
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.titi.titi_auth.application.port.in.GenerateAccessTokenUseCase;
+import com.titi.titi_auth.application.port.out.cache.PutRefreshTokenPort;
+
+@Service
+@RequiredArgsConstructor
+class GenerateAccessTokenService implements GenerateAccessTokenUseCase {
+
+	private final JwtService jwtService;
+	private final PutRefreshTokenPort putRefreshTokenPort;
+
+	@Override
+	public Result invoke(Command command) {
+		final JwtService.Subject subject = JwtService.Subject.builder()
+			.memberId(command.memberId())
+			.deviceId(command.deviceId())
+			.build();
+		Instant now = Instant.now();
+		final String accessToken = this.jwtService.generateAccessToken(subject, now);
+		final String refreshToken = this.jwtService.generateRefreshToken(subject, now);
+		this.putRefreshTokenPort.invoke(
+			PutRefreshTokenPort.Command.builder()
+				.subject(subject.generateHashValue())
+				.refreshToken(refreshToken)
+				.build()
+		);
+		return Result.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/application/service/JwtService.java
+++ b/src/main/java/com/titi/titi_auth/application/service/JwtService.java
@@ -1,0 +1,71 @@
+package com.titi.titi_auth.application.service;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+import com.titi.titi_auth.application.common.constant.AuthConstants;
+import com.titi.titi_auth.common.TiTiAuthBusinessCodes;
+import com.titi.titi_auth.common.TiTiAuthException;
+import com.titi.titi_common_lib.util.JacksonHelper;
+import com.titi.titi_common_lib.util.JwtUtils;
+import com.titi.titi_crypto_lib.util.HashingUtils;
+
+@Component
+@RequiredArgsConstructor
+class JwtService {
+
+	private final JwtUtils jwtUtils;
+
+	private String generateJWT(Subject subject, Date now, Date expirationTime, String type) {
+		return this.jwtUtils.generate(
+			JwtUtils.Payload.builder()
+				.registeredClaim(
+					JwtUtils.Payload.RegisteredClaim.builder()
+						.issuer(AuthConstants.JWT_ISSUER)
+						.subject(JacksonHelper.toJson(subject))
+						.expirationTime(expirationTime)
+						.issuedAt(now)
+						.jwtId(UUID.randomUUID().toString())
+						.build()
+				)
+				.additionalClaims(Map.of(JwtUtils.Payload.TYPE, type))
+				.build()
+		);
+	}
+
+	String generateAccessToken(Subject subject, Instant now) {
+		return this.generateJWT(subject, Date.from(now), Date.from(now.plusSeconds(AuthConstants.ACCESS_TOKEN_EXPIRATION_TIME)), AuthConstants.ACCESS_TOKEN);
+	}
+
+	String generateRefreshToken(Subject subject, Instant now) {
+		return this.generateJWT(subject, Date.from(now), Date.from(now.plusSeconds(AuthConstants.REFRESH_TOKEN_EXPIRATION_TIME)), AuthConstants.REFRESH_TOKEN);
+	}
+
+	Subject extractSubject(String jwt, String type) {
+		try {
+			return JacksonHelper.fromJson(this.jwtUtils.getPayloads(jwt, type).getSubject(), Subject.class);
+		} catch (IllegalArgumentException e) {
+			throw new TiTiAuthException(TiTiAuthBusinessCodes.REISSUE_ACCESS_TOKEN_FAILURE_INVALID_REFRESH_TOKEN);
+		}
+	}
+
+	@Builder
+	record Subject(
+		String memberId,
+		String deviceId
+	) {
+
+		public String generateHashValue() {
+			return HashingUtils.hashSha256(this.memberId, this.deviceId);
+		}
+
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/application/service/ReissueAccessTokenService.java
+++ b/src/main/java/com/titi/titi_auth/application/service/ReissueAccessTokenService.java
@@ -1,0 +1,53 @@
+package com.titi.titi_auth.application.service;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.titi.titi_auth.application.common.constant.AuthConstants;
+import com.titi.titi_auth.application.port.in.ReissueAccessTokenUseCase;
+import com.titi.titi_auth.application.port.out.cache.GetRefreshTokenPort;
+import com.titi.titi_auth.application.port.out.cache.PutRefreshTokenPort;
+import com.titi.titi_auth.common.TiTiAuthBusinessCodes;
+import com.titi.titi_auth.common.TiTiAuthException;
+
+@Service
+@RequiredArgsConstructor
+class ReissueAccessTokenService implements ReissueAccessTokenUseCase {
+
+	private final GetRefreshTokenPort getRefreshTokenPort;
+	private final PutRefreshTokenPort putRefreshTokenPort;
+	private final JwtService jwtService;
+
+	@Override
+	public Result invoke(Command command) {
+		final JwtService.Subject subject = this.jwtService.extractSubject(command.refreshToken(), AuthConstants.REFRESH_TOKEN);
+		final String hashedSubject = subject.generateHashValue();
+		this.validateRefreshToken(command.refreshToken(), hashedSubject);
+		Instant now = Instant.now();
+		final String accessToken = this.jwtService.generateAccessToken(subject, now);
+		final String refreshToken = this.jwtService.generateRefreshToken(subject, now);
+		this.putRefreshTokenPort.invoke(
+			PutRefreshTokenPort.Command.builder()
+				.subject(hashedSubject)
+				.refreshToken(refreshToken)
+				.build()
+		);
+		return Result.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
+	}
+
+	private void validateRefreshToken(String refreshToken, String subject) {
+		final GetRefreshTokenPort.Result invoke = this.getRefreshTokenPort.invoke(GetRefreshTokenPort.Command.builder().subject(subject).build());
+		final Optional<String> cachedRefreshToken = invoke.refreshToken();
+		if (cachedRefreshToken.isEmpty() || !refreshToken.equals(cachedRefreshToken.get())) {
+			throw new TiTiAuthException(TiTiAuthBusinessCodes.REISSUE_ACCESS_TOKEN_FAILURE_INVALID_REFRESH_TOKEN);
+		}
+	}
+
+}

--- a/src/main/java/com/titi/titi_auth/common/TiTiAuthBusinessCodes.java
+++ b/src/main/java/com/titi/titi_auth/common/TiTiAuthBusinessCodes.java
@@ -11,9 +11,12 @@ public enum TiTiAuthBusinessCodes {
 	VERIFY_AUTH_CODE_SUCCESS(200, "AU1001", "Successfully verifying the authentication code issues an authentication token."),
 	INVALID_AUTH_CODE(200, "AU1002", "The authentication code has expired or is invalid."),
 	MISMATCHED_AUTH_CODE(200, "AU1003", "The authentication code does not match."),
+	REISSUE_ACCESS_TOKEN_SUCCESS(200, "AU1004", "Successfully reissued the Access Token."),
+	REISSUE_ACCESS_TOKEN_FAILURE_INVALID_REFRESH_TOKEN(200, "AU1005", "The Refresh Token is invalid, so the reissuance of the Access Token has failed."),
 
 	GENERATE_AUTH_CODE_FAILURE(500, "AU7000", "Failed to generate and transmit the authentication code. Please try again later."),
 	VERIFY_AUTH_CODE_FAILURE(500, "AU7001", "Authentication code verification failed. Please try again later."),
+	CACHE_SERVER_ERROR(500, "AU9000", "Cache server error. Please try again later"),
 	;
 
 	private final int status;

--- a/src/main/java/com/titi/titi_user/adapter/in/web/api/LoginController.java
+++ b/src/main/java/com/titi/titi_user/adapter/in/web/api/LoginController.java
@@ -34,6 +34,7 @@ class LoginController implements UserApi {
 			LoginUseCase.Command.builder()
 				.username(requestBody.username())
 				.encodedEncryptedPassword(EncodedEncryptedPassword.builder().value(requestBody.encodedEncryptedPassword()).build())
+				.deviceId(requestBody.deviceId())
 				.build()
 		);
 		return ResponseEntity.status(TiTiUserBusinessCodes.LOGIN_SUCCESS.getStatus())
@@ -58,7 +59,11 @@ class LoginController implements UserApi {
 			description = "it is encrypted using AES-256 to wrap the raw_password then encoded using base64url.",
 			requiredMode = Schema.RequiredMode.REQUIRED,
 			example = "6o171NOMWMJ2BMgouXrOr82lFLFFo-hA9qphcA=="
-		) @NotBlank String encodedEncryptedPassword
+		) @NotBlank String encodedEncryptedPassword,
+		@Schema(
+			description = "An identifier that distinguishes the device. It can be obtained through the IssueDeviceId API.",
+			requiredMode = Schema.RequiredMode.REQUIRED
+		) @NotBlank String deviceId
 	) {
 
 	}

--- a/src/main/java/com/titi/titi_user/adapter/out/internal/GenerateAccessTokenPortAdapter.java
+++ b/src/main/java/com/titi/titi_user/adapter/out/internal/GenerateAccessTokenPortAdapter.java
@@ -1,0 +1,30 @@
+package com.titi.titi_user.adapter.out.internal;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+import com.titi.titi_auth.adapter.in.internal.GenerateAccessTokenGateway;
+import com.titi.titi_user.application.port.out.internal.GenerateAccessTokenPort;
+
+@Component
+@RequiredArgsConstructor
+class GenerateAccessTokenPortAdapter implements GenerateAccessTokenPort {
+
+	private final GenerateAccessTokenGateway generateAccessTokenGateway;
+
+	@Override
+	public Result invoke(Command command) {
+		final GenerateAccessTokenGateway.GenerateAccessTokenResponse response = this.generateAccessTokenGateway.invoke(
+			GenerateAccessTokenGateway.GenerateAccessTokenRequest.builder()
+				.memberId(command.memberId())
+				.deviceId(command.deviceId())
+				.build()
+		);
+		return Result.builder()
+			.accessToken(response.accessToken())
+			.refreshToken(response.refreshToken())
+			.build();
+	}
+
+}

--- a/src/main/java/com/titi/titi_user/application/common/constant/UserConstants.java
+++ b/src/main/java/com/titi/titi_user/application/common/constant/UserConstants.java
@@ -1,7 +1,5 @@
 package com.titi.titi_user.application.common.constant;
 
-import static com.titi.titi_common_lib.constant.Constants.*;
-
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -9,17 +7,6 @@ import lombok.NoArgsConstructor;
 public class UserConstants {
 
 	public static final String SERVICE_NAME = "USER";
-	public static final String JWT_ISSUER = "TiTi-User";
 	public static final String AUTH_TOKEN = "authToken";
-	public static final String ACCESS_TOKEN = "accessToken";
-	public static final String REFRESH_TOKEN = "refreshToken";
-	/**
-	 * 30 minutes
-	 */
-	public static final int ACCESS_TOKEN_EXPIRATION_TIME = 30 * 60 * SECONDS;
-	/**
-	 * 2 weeks
-	 */
-	public static final int REFRESH_TOKEN_EXPIRATION_TIME = 14 * 24 * 60 * 60 * SECONDS;
 
 }

--- a/src/main/java/com/titi/titi_user/application/port/in/LoginUseCase.java
+++ b/src/main/java/com/titi/titi_user/application/port/in/LoginUseCase.java
@@ -11,7 +11,8 @@ public interface LoginUseCase {
 	@Builder
 	record Command(
 		String username,
-		EncodedEncryptedPassword encodedEncryptedPassword
+		EncodedEncryptedPassword encodedEncryptedPassword,
+		String deviceId
 	) {
 
 	}

--- a/src/main/java/com/titi/titi_user/application/port/out/internal/GenerateAccessTokenPort.java
+++ b/src/main/java/com/titi/titi_user/application/port/out/internal/GenerateAccessTokenPort.java
@@ -1,0 +1,25 @@
+package com.titi.titi_user.application.port.out.internal;
+
+import lombok.Builder;
+
+public interface GenerateAccessTokenPort {
+
+	Result invoke(Command command);
+
+	@Builder
+	record Command(
+		String memberId,
+		String deviceId
+	) {
+
+	}
+
+	@Builder
+	record Result(
+		String accessToken,
+		String refreshToken
+	) {
+
+	}
+
+}

--- a/src/main/java/com/titi/titi_user/application/service/LoginService.java
+++ b/src/main/java/com/titi/titi_user/application/service/LoginService.java
@@ -1,19 +1,13 @@
 package com.titi.titi_user.application.service;
 
-import java.time.Instant;
-import java.util.Date;
-import java.util.Map;
-import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 
-import com.titi.titi_common_lib.util.JwtUtils;
-import com.titi.titi_user.application.common.constant.UserConstants;
 import com.titi.titi_user.application.port.in.LoginUseCase;
+import com.titi.titi_user.application.port.out.internal.GenerateAccessTokenPort;
 import com.titi.titi_user.application.port.out.persistence.FindMemberPort;
 import com.titi.titi_user.common.TiTiUserBusinessCodes;
 import com.titi.titi_user.common.TiTiUserException;
@@ -25,7 +19,7 @@ class LoginService implements LoginUseCase {
 
 	private final FindMemberPort findMemberPort;
 	private final PasswordEncoder passwordEncoder;
-	private final JwtUtils jwtUtils;
+	private final GenerateAccessTokenPort generateAccessTokenPort;
 	@Value("${crypto.secret-key}")
 	private String secretKey;
 
@@ -35,10 +29,15 @@ class LoginService implements LoginUseCase {
 			.orElseThrow(() -> new TiTiUserException(TiTiUserBusinessCodes.LOGIN_FAILURE_MISMATCHED_MEMBER_INFORMATION));
 		final String rawPassword = command.encodedEncryptedPassword().getRawPassword(this.secretKey.getBytes());
 		this.validatePassword(rawPassword, member);
-		final Instant now = Instant.now();
+		final GenerateAccessTokenPort.Result result = this.generateAccessTokenPort.invoke(
+			GenerateAccessTokenPort.Command.builder()
+				.memberId(String.valueOf(member.id()))
+				.deviceId(command.deviceId())
+				.build()
+		);
 		return Result.builder()
-			.accessToken(this.generateAccessToken(member, now))
-			.refreshToken(this.generateRefreshToken(member, now))
+			.accessToken(result.accessToken())
+			.refreshToken(result.refreshToken())
 			.build();
 	}
 
@@ -46,31 +45,6 @@ class LoginService implements LoginUseCase {
 		if (!this.passwordEncoder.matches(rawPassword, member.password())) {
 			throw new TiTiUserException(TiTiUserBusinessCodes.LOGIN_FAILURE_MISMATCHED_MEMBER_INFORMATION);
 		}
-	}
-
-	private String generateAccessToken(Member member, Instant now) {
-		return this.generateJWT(member.id().toString(), Date.from(now), Date.from(now.plusSeconds(UserConstants.ACCESS_TOKEN_EXPIRATION_TIME)), UserConstants.ACCESS_TOKEN);
-	}
-
-	private String generateRefreshToken(Member member, Instant now) {
-		return this.generateJWT(member.id().toString(), Date.from(now), Date.from(now.plusSeconds(UserConstants.REFRESH_TOKEN_EXPIRATION_TIME)), UserConstants.REFRESH_TOKEN);
-	}
-
-	private String generateJWT(String subject, Date now, Date expirationTime, String type) {
-		return this.jwtUtils.generate(
-			JwtUtils.Payload.builder()
-				.registeredClaim(
-					JwtUtils.Payload.RegisteredClaim.builder()
-						.issuer(UserConstants.JWT_ISSUER)
-						.subject(subject)
-						.expirationTime(expirationTime)
-						.issuedAt(now)
-						.jwtId(UUID.randomUUID().toString())
-						.build()
-				)
-				.additionalClaims(Map.of(JwtUtils.Payload.TYPE, type))
-				.build()
-		);
 	}
 
 }

--- a/src/test/java/com/titi/titi_auth/adapter/in/internal/GenerateAccessTokenGatewayTest.java
+++ b/src/test/java/com/titi/titi_auth/adapter/in/internal/GenerateAccessTokenGatewayTest.java
@@ -1,0 +1,47 @@
+package com.titi.titi_auth.adapter.in.internal;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.titi_auth.application.port.in.GenerateAccessTokenUseCase;
+
+@ExtendWith(MockitoExtension.class)
+class GenerateAccessTokenGatewayTest {
+
+	@Mock
+	private GenerateAccessTokenUseCase generateAccessTokenUseCase;
+
+	@InjectMocks
+	private GenerateAccessTokenGateway generateAccessTokenGateway;
+
+	@Test
+	void invoke() {
+		// given
+		final GenerateAccessTokenUseCase.Result result = GenerateAccessTokenUseCase.Result.builder()
+			.accessToken("accessToken")
+			.refreshToken("refreshToken")
+			.build();
+		given(generateAccessTokenUseCase.invoke(any(GenerateAccessTokenUseCase.Command.class))).willReturn(result);
+
+		// when
+		final GenerateAccessTokenGateway.GenerateAccessTokenRequest request = GenerateAccessTokenGateway.GenerateAccessTokenRequest.builder()
+			.memberId(String.valueOf(1L))
+			.deviceId(UUID.randomUUID().toString())
+			.build();
+		final GenerateAccessTokenGateway.GenerateAccessTokenResponse response = generateAccessTokenGateway.invoke(request);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response).usingRecursiveComparison().isEqualTo(result);
+		verify(generateAccessTokenUseCase, times(1)).invoke(any(GenerateAccessTokenUseCase.Command.class));
+	}
+
+}

--- a/src/test/java/com/titi/titi_auth/adapter/in/internal/mapper/AuthInternalMapperTest.java
+++ b/src/test/java/com/titi/titi_auth/adapter/in/internal/mapper/AuthInternalMapperTest.java
@@ -1,0 +1,81 @@
+package com.titi.titi_auth.adapter.in.internal.mapper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.titi.titi_auth.adapter.in.internal.GenerateAccessTokenGateway;
+import com.titi.titi_auth.application.port.in.GenerateAccessTokenUseCase;
+
+class AuthInternalMapperTest {
+
+	@Nested
+	class ToCommand {
+
+		@Test
+		void whenRequestIsNotNullScenario() {
+			// given
+			final GenerateAccessTokenGateway.GenerateAccessTokenRequest request = GenerateAccessTokenGateway.GenerateAccessTokenRequest.builder()
+				.memberId(String.valueOf(1L))
+				.deviceId(UUID.randomUUID().toString())
+				.build();
+
+			// when
+			final GenerateAccessTokenUseCase.Command command = AuthInternalMapper.INSTANCE.toCommand(request);
+
+			// then
+			assertThat(command).isNotNull();
+			assertThat(command).usingRecursiveComparison().isEqualTo(request);
+		}
+
+		@Test
+		void whenRequestIsNullScenario() {
+			// given
+			final GenerateAccessTokenGateway.GenerateAccessTokenRequest request = null;
+
+			// when
+			final GenerateAccessTokenUseCase.Command command = AuthInternalMapper.INSTANCE.toCommand(request);
+
+			// then
+			assertThat(command).isNull();
+		}
+
+	}
+
+	@Nested
+	class ToResponse {
+
+		@Test
+		void whenResultIsNotNullScenario() {
+			// given
+			final GenerateAccessTokenUseCase.Result result = GenerateAccessTokenUseCase.Result.builder()
+				.accessToken("accessToken")
+				.refreshToken("refreshToken")
+				.build();
+
+			// when
+			final GenerateAccessTokenGateway.GenerateAccessTokenResponse response = AuthInternalMapper.INSTANCE.toResponse(result);
+
+			// then
+			assertThat(response).isNotNull();
+			assertThat(response).usingRecursiveComparison().isEqualTo(result);
+		}
+
+		@Test
+		void whenResultIsNullScenario() {
+			// given
+			final GenerateAccessTokenUseCase.Result result = null;
+
+			// when
+			final GenerateAccessTokenGateway.GenerateAccessTokenResponse response = AuthInternalMapper.INSTANCE.toResponse(result);
+
+			// then
+			assertThat(response).isNull();
+		}
+
+	}
+
+}

--- a/src/test/java/com/titi/titi_auth/adapter/in/web/api/ReissueAccessTokenControllerTest.java
+++ b/src/test/java/com/titi/titi_auth/adapter/in/web/api/ReissueAccessTokenControllerTest.java
@@ -1,0 +1,67 @@
+package com.titi.titi_auth.adapter.in.web.api;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.titi.titi_auth.application.port.in.ReissueAccessTokenUseCase;
+import com.titi.titi_auth.common.TiTiAuthBusinessCodes;
+import com.titi.titi_common_lib.util.JacksonHelper;
+
+@WebMvcTest(controllers = ReissueAccessTokenController.class)
+class ReissueAccessTokenControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private ReissueAccessTokenUseCase reissueAccessTokenUseCase;
+
+	private ResultActions mockReissueAccessToken(ReissueAccessTokenController.ReissueAccessTokenRequestBody requestBody) throws Exception {
+		return mockMvc.perform(post("/api/auth/token/reissue")
+			.content(JacksonHelper.toJson(requestBody))
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.with(csrf()));
+	}
+
+	private ReissueAccessTokenController.ReissueAccessTokenRequestBody getReissueAccessTokenRequestBody() {
+		return ReissueAccessTokenController.ReissueAccessTokenRequestBody.builder()
+			.refreshToken("refreshToken")
+			.build();
+	}
+
+	@Test
+	@WithMockUser
+	void whenSuccessToReissueAccessTokenThenCodeIsAU1004() throws Exception {
+		// given
+		final ReissueAccessTokenUseCase.Result result = ReissueAccessTokenUseCase.Result.builder()
+			.accessToken("accessToken")
+			.refreshToken("refreshToken")
+			.build();
+		given(reissueAccessTokenUseCase.invoke(any(ReissueAccessTokenUseCase.Command.class))).willReturn(result);
+		final ReissueAccessTokenController.ReissueAccessTokenRequestBody requestBody = getReissueAccessTokenRequestBody();
+
+		// when
+		final ResultActions perform = mockReissueAccessToken(requestBody);
+
+		// then
+		perform.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(TiTiAuthBusinessCodes.REISSUE_ACCESS_TOKEN_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.message").value(TiTiAuthBusinessCodes.REISSUE_ACCESS_TOKEN_SUCCESS.getMessage()))
+			.andExpect(jsonPath("$.access_token").isNotEmpty())
+			.andExpect(jsonPath("$.refresh_token").isNotEmpty());
+		verify(reissueAccessTokenUseCase, times(1)).invoke(any(ReissueAccessTokenUseCase.Command.class));
+	}
+
+}

--- a/src/test/java/com/titi/titi_auth/adapter/out/cache/GetRefreshTokenPortAdapterTest.java
+++ b/src/test/java/com/titi/titi_auth/adapter/out/cache/GetRefreshTokenPortAdapterTest.java
@@ -1,0 +1,78 @@
+package com.titi.titi_auth.adapter.out.cache;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.infrastructure.cache.CacheManager;
+import com.titi.titi_auth.application.port.out.cache.GetRefreshTokenPort;
+import com.titi.titi_auth.common.TiTiAuthException;
+
+@ExtendWith(MockitoExtension.class)
+class GetRefreshTokenPortAdapterTest {
+
+	@Mock
+	private CacheManager cacheManager;
+
+	@InjectMocks
+	private GetRefreshTokenPortAdapter getRefreshTokenPortAdapter;
+
+	@Test
+	void successfulScenario() throws Exception {
+		// given
+		given(cacheManager.get(anyString())).willReturn(Optional.of("refreshToken"));
+
+		// when
+		final GetRefreshTokenPort.Command command = GetRefreshTokenPort.Command.builder()
+			.subject("subject")
+			.build();
+		final GetRefreshTokenPort.Result result = getRefreshTokenPortAdapter.invoke(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.refreshToken().isPresent()).isTrue();
+		verify(cacheManager, times(1)).get(anyString());
+	}
+
+	@Test
+	void successfulButEmptyScenario() throws Exception {
+		// given
+		given(cacheManager.get(anyString())).willReturn(Optional.empty());
+
+		// when
+		final GetRefreshTokenPort.Command command = GetRefreshTokenPort.Command.builder()
+			.subject("subject")
+			.build();
+		final GetRefreshTokenPort.Result result = getRefreshTokenPortAdapter.invoke(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.refreshToken().isEmpty()).isTrue();
+		verify(cacheManager, times(1)).get(anyString());
+	}
+
+	@Test
+	void cacheServerErrorScenario() throws Exception {
+		// given
+		given(cacheManager.get(anyString())).willThrow(Exception.class);
+
+		// when
+		final GetRefreshTokenPort.Command command = GetRefreshTokenPort.Command.builder()
+			.subject("subject")
+			.build();
+		final ThrowableAssert.ThrowingCallable throwingCallable = () -> getRefreshTokenPortAdapter.invoke(command);
+
+		// then
+		assertThatCode(throwingCallable).isInstanceOf(TiTiAuthException.class);
+		verify(cacheManager, times(1)).get(anyString());
+	}
+
+}

--- a/src/test/java/com/titi/titi_auth/adapter/out/cache/PutRefreshTokenPortAdapterTest.java
+++ b/src/test/java/com/titi/titi_auth/adapter/out/cache/PutRefreshTokenPortAdapterTest.java
@@ -1,0 +1,57 @@
+package com.titi.titi_auth.adapter.out.cache;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.infrastructure.cache.CacheManager;
+import com.titi.titi_auth.application.port.out.cache.PutRefreshTokenPort;
+import com.titi.titi_auth.common.TiTiAuthException;
+
+@ExtendWith(MockitoExtension.class)
+class PutRefreshTokenPortAdapterTest {
+
+	@Mock
+	private CacheManager cacheManager;
+
+	@InjectMocks
+	private PutRefreshTokenPortAdapter putRefreshTokenPortAdapter;
+
+	@Test
+	void successfulScenario() throws Exception {
+		// when
+		final PutRefreshTokenPort.Command command = PutRefreshTokenPort.Command.builder()
+			.subject("subject")
+			.refreshToken("refreshToken")
+			.build();
+		final ThrowableAssert.ThrowingCallable throwingCallable = () -> putRefreshTokenPortAdapter.invoke(command);
+
+		// then
+		assertThatCode(throwingCallable).doesNotThrowAnyException();
+		verify(cacheManager, times(1)).put(anyString(), anyString(), eq(AuthCacheKeys.REFRESH_TOKEN.getTimeToLive()));
+	}
+
+	@Test
+	void cacheServerErrorScenario() throws Exception {
+		// given
+		doThrow(Exception.class).when(cacheManager).put(anyString(), anyString(), eq(AuthCacheKeys.REFRESH_TOKEN.getTimeToLive()));
+
+		// when
+		final PutRefreshTokenPort.Command command = PutRefreshTokenPort.Command.builder()
+			.subject("subject")
+			.refreshToken("refreshToken")
+			.build();
+		final ThrowableAssert.ThrowingCallable throwingCallable = () -> putRefreshTokenPortAdapter.invoke(command);
+
+		// then
+		assertThatCode(throwingCallable).isInstanceOf(TiTiAuthException.class);
+		verify(cacheManager, times(1)).put(anyString(), anyString(), eq(AuthCacheKeys.REFRESH_TOKEN.getTimeToLive()));
+	}
+
+}

--- a/src/test/java/com/titi/titi_auth/application/service/GenerateAccessTokenServiceTest.java
+++ b/src/test/java/com/titi/titi_auth/application/service/GenerateAccessTokenServiceTest.java
@@ -1,0 +1,51 @@
+package com.titi.titi_auth.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.titi_auth.application.port.in.GenerateAccessTokenUseCase;
+import com.titi.titi_auth.application.port.out.cache.PutRefreshTokenPort;
+
+@ExtendWith(MockitoExtension.class)
+class GenerateAccessTokenServiceTest {
+
+	@Mock
+	private JwtService jwtService;
+
+	@Mock
+	private PutRefreshTokenPort putRefreshTokenPort;
+
+	@InjectMocks
+	private GenerateAccessTokenService generateAccessTokenService;
+
+	@Test
+	void invoke() {
+		// given
+		given(jwtService.generateAccessToken(any(JwtService.Subject.class), any(Instant.class))).willReturn("accessToken");
+		given(jwtService.generateRefreshToken(any(JwtService.Subject.class), any(Instant.class))).willReturn("refreshToken");
+
+		// when
+		final GenerateAccessTokenUseCase.Command command = GenerateAccessTokenUseCase.Command.builder()
+			.memberId(String.valueOf(1L))
+			.deviceId(UUID.randomUUID().toString())
+			.build();
+		final GenerateAccessTokenUseCase.Result result = generateAccessTokenService.invoke(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result).usingRecursiveComparison().isNotNull();
+		verify(jwtService, times(1)).generateAccessToken(any(JwtService.Subject.class), any(Instant.class));
+		verify(jwtService, times(1)).generateRefreshToken(any(JwtService.Subject.class), any(Instant.class));
+		verify(putRefreshTokenPort, times(1)).invoke(any(PutRefreshTokenPort.Command.class));
+	}
+
+}

--- a/src/test/java/com/titi/titi_auth/application/service/JwtServiceTest.java
+++ b/src/test/java/com/titi/titi_auth/application/service/JwtServiceTest.java
@@ -1,0 +1,100 @@
+package com.titi.titi_auth.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.jsonwebtoken.Claims;
+
+import com.titi.titi_auth.application.common.constant.AuthConstants;
+import com.titi.titi_auth.common.TiTiAuthException;
+import com.titi.titi_common_lib.util.JacksonHelper;
+import com.titi.titi_common_lib.util.JwtUtils;
+
+@ExtendWith(MockitoExtension.class)
+class JwtServiceTest {
+
+	private static final JwtService.Subject SUBJECT = JwtService.Subject.builder()
+		.memberId(String.valueOf(1L))
+		.deviceId(UUID.randomUUID().toString())
+		.build();
+
+	@Mock
+	private JwtUtils jwtUtils;
+
+	@InjectMocks
+	private JwtService jwtService;
+
+	@Test
+	void generateAccessTokenTest() {
+		// given
+		given(jwtUtils.generate(any(JwtUtils.Payload.class))).willReturn("accessToken");
+
+		// when
+		final String accessToken = jwtService.generateAccessToken(SUBJECT, Instant.now());
+
+		// then
+		assertThat(accessToken).isNotBlank();
+		verify(jwtUtils, times(1)).generate(any(JwtUtils.Payload.class));
+	}
+
+	@Test
+	void generateRefreshTokenTest() {
+		// given
+		given(jwtUtils.generate(any(JwtUtils.Payload.class))).willReturn("refreshToken");
+
+		// when
+		final String refreshToken = jwtService.generateRefreshToken(SUBJECT, Instant.now());
+
+		// then
+		assertThat(refreshToken).isNotBlank();
+		verify(jwtUtils, times(1)).generate(any(JwtUtils.Payload.class));
+	}
+
+	@Nested
+	class ExtractSubject {
+
+		@Test
+		void successScenario() {
+			// given
+			final Claims mockClaims = mock(Claims.class);
+			given(mockClaims.getSubject()).willReturn(JacksonHelper.toJson(SUBJECT));
+			given(jwtUtils.getPayloads(anyString(), anyString())).willReturn(mockClaims);
+
+			// when
+			final String mockJwt = "jwt";
+			final JwtService.Subject subject = jwtService.extractSubject(mockJwt, AuthConstants.ACCESS_TOKEN);
+
+			// then
+			assertThat(subject).isNotNull();
+			assertThat(subject).usingRecursiveComparison().isEqualTo(SUBJECT);
+			verify(jwtUtils, times(1)).getPayloads(anyString(), anyString());
+		}
+
+		@Test
+		void failureScenario() {
+			// given
+			given(jwtUtils.getPayloads(anyString(), anyString())).willThrow(IllegalArgumentException.class);
+
+			// when
+			final String mockJwt = "jwt";
+			final ThrowableAssert.ThrowingCallable throwingCallable = () -> jwtService.extractSubject(mockJwt, AuthConstants.ACCESS_TOKEN);
+
+			// then
+			assertThatCode(throwingCallable).isInstanceOf(TiTiAuthException.class);
+			verify(jwtUtils, times(1)).getPayloads(anyString(), anyString());
+		}
+
+	}
+
+}

--- a/src/test/java/com/titi/titi_auth/application/service/ReissueAccessTokenServiceTest.java
+++ b/src/test/java/com/titi/titi_auth/application/service/ReissueAccessTokenServiceTest.java
@@ -1,0 +1,122 @@
+package com.titi.titi_auth.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.titi_auth.application.common.constant.AuthConstants;
+import com.titi.titi_auth.application.port.in.ReissueAccessTokenUseCase;
+import com.titi.titi_auth.application.port.out.cache.GetRefreshTokenPort;
+import com.titi.titi_auth.application.port.out.cache.PutRefreshTokenPort;
+import com.titi.titi_auth.common.TiTiAuthException;
+
+@ExtendWith(MockitoExtension.class)
+class ReissueAccessTokenServiceTest {
+
+	@Mock
+	private GetRefreshTokenPort getRefreshTokenPort;
+
+	@Mock
+	private PutRefreshTokenPort putRefreshTokenPort;
+
+	@Mock
+	private JwtService jwtService;
+
+	@InjectMocks
+	private ReissueAccessTokenService reissueAccessTokenService;
+
+	@Test
+	void successfulScenario() {
+		// given
+		final JwtService.Subject subject = JwtService.Subject.builder()
+			.memberId(String.valueOf(1L))
+			.deviceId(UUID.randomUUID().toString())
+			.build();
+		given(jwtService.extractSubject(anyString(), eq(AuthConstants.REFRESH_TOKEN))).willReturn(subject);
+		final GetRefreshTokenPort.Result mockResult = mock(GetRefreshTokenPort.Result.class);
+		given(mockResult.refreshToken()).willReturn(Optional.of("refreshToken"));
+		given(getRefreshTokenPort.invoke(any(GetRefreshTokenPort.Command.class))).willReturn(mockResult);
+		given(jwtService.generateAccessToken(eq(subject), any(Instant.class))).willReturn("accessToken");
+		given(jwtService.generateRefreshToken(eq(subject), any(Instant.class))).willReturn("refreshToken");
+
+		// when
+		final ReissueAccessTokenUseCase.Command command = ReissueAccessTokenUseCase.Command.builder()
+			.refreshToken("refreshToken")
+			.build();
+		final ReissueAccessTokenUseCase.Result result = reissueAccessTokenService.invoke(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result).usingRecursiveComparison().isNotNull();
+		verify(jwtService, times(1)).extractSubject(anyString(), eq(AuthConstants.REFRESH_TOKEN));
+		verify(getRefreshTokenPort, times(1)).invoke(any(GetRefreshTokenPort.Command.class));
+		verify(jwtService, times(1)).generateAccessToken(eq(subject), any(Instant.class));
+		verify(jwtService, times(1)).generateRefreshToken(eq(subject), any(Instant.class));
+		verify(putRefreshTokenPort, times(1)).invoke(any(PutRefreshTokenPort.Command.class));
+	}
+
+	@Test
+	void whenCachedRefreshTokenIsInvalidThenValidateRefreshTokenFailureScenario() {
+		// given
+		final JwtService.Subject subject = JwtService.Subject.builder()
+			.memberId(String.valueOf(1L))
+			.deviceId(UUID.randomUUID().toString())
+			.build();
+		given(jwtService.extractSubject(anyString(), eq(AuthConstants.REFRESH_TOKEN))).willReturn(subject);
+		final GetRefreshTokenPort.Result mockResult = mock(GetRefreshTokenPort.Result.class);
+		given(mockResult.refreshToken()).willReturn(Optional.empty());
+		given(getRefreshTokenPort.invoke(any(GetRefreshTokenPort.Command.class))).willReturn(mockResult);
+
+		// when
+		final ReissueAccessTokenUseCase.Command command = ReissueAccessTokenUseCase.Command.builder()
+			.refreshToken("refreshToken")
+			.build();
+		final ThrowableAssert.ThrowingCallable throwingCallable = () -> reissueAccessTokenService.invoke(command);
+
+		// then
+		assertThatCode(throwingCallable).isInstanceOf(TiTiAuthException.class);
+		verify(jwtService, times(1)).extractSubject(anyString(), eq(AuthConstants.REFRESH_TOKEN));
+		verify(getRefreshTokenPort, times(1)).invoke(any(GetRefreshTokenPort.Command.class));
+		verify(jwtService, never()).generateAccessToken(eq(subject), any(Instant.class));
+		verify(jwtService, never()).generateRefreshToken(eq(subject), any(Instant.class));
+		verify(putRefreshTokenPort, never()).invoke(any(PutRefreshTokenPort.Command.class));
+	}
+
+	@Test
+	void whenCachedRefreshTokenIsMisMatchedThenValidateRefreshTokenFailureScenario() {
+		// given
+		final JwtService.Subject subject = JwtService.Subject.builder()
+			.memberId(String.valueOf(1L))
+			.deviceId(UUID.randomUUID().toString())
+			.build();
+		given(jwtService.extractSubject(anyString(), eq(AuthConstants.REFRESH_TOKEN))).willReturn(subject);
+		final GetRefreshTokenPort.Result mockResult = mock(GetRefreshTokenPort.Result.class);
+		given(mockResult.refreshToken()).willReturn(Optional.of("mismatchedRefreshToken"));
+		given(getRefreshTokenPort.invoke(any(GetRefreshTokenPort.Command.class))).willReturn(mockResult);
+
+		// when
+		final ReissueAccessTokenUseCase.Command command = ReissueAccessTokenUseCase.Command.builder()
+			.refreshToken("refreshToken")
+			.build();
+		final ThrowableAssert.ThrowingCallable throwingCallable = () -> reissueAccessTokenService.invoke(command);
+
+		// then
+		assertThatCode(throwingCallable).isInstanceOf(TiTiAuthException.class);
+		verify(jwtService, times(1)).extractSubject(anyString(), eq(AuthConstants.REFRESH_TOKEN));
+		verify(getRefreshTokenPort, times(1)).invoke(any(GetRefreshTokenPort.Command.class));
+		verify(jwtService, never()).generateAccessToken(eq(subject), any(Instant.class));
+		verify(jwtService, never()).generateRefreshToken(eq(subject), any(Instant.class));
+		verify(putRefreshTokenPort, never()).invoke(any(PutRefreshTokenPort.Command.class));
+	}
+
+}

--- a/src/test/java/com/titi/titi_user/adapter/in/web/api/LoginControllerTest.java
+++ b/src/test/java/com/titi/titi_user/adapter/in/web/api/LoginControllerTest.java
@@ -5,6 +5,8 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -33,6 +35,7 @@ class LoginControllerTest {
 		return LoginRequestBody.builder()
 			.username("test@gmail.com")
 			.encodedEncryptedPassword("encodedEncryptedPassword")
+			.deviceId(UUID.randomUUID().toString())
 			.build();
 	}
 

--- a/src/test/java/com/titi/titi_user/adapter/out/internal/GenerateAccessTokenPortAdapterTest.java
+++ b/src/test/java/com/titi/titi_user/adapter/out/internal/GenerateAccessTokenPortAdapterTest.java
@@ -1,0 +1,48 @@
+package com.titi.titi_user.adapter.out.internal;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.titi_auth.adapter.in.internal.GenerateAccessTokenGateway;
+import com.titi.titi_user.application.port.out.internal.GenerateAccessTokenPort;
+
+@ExtendWith(MockitoExtension.class)
+class GenerateAccessTokenPortAdapterTest {
+
+	@Mock
+	private GenerateAccessTokenGateway generateAccessTokenGateway;
+
+	@InjectMocks
+	private GenerateAccessTokenPortAdapter generateAccessTokenPortAdapter;
+
+	@Test
+	void invoke() {
+		// given
+		final GenerateAccessTokenGateway.GenerateAccessTokenResponse response = GenerateAccessTokenGateway.GenerateAccessTokenResponse.builder()
+			.accessToken("accessToken")
+			.refreshToken("refreshToken")
+			.build();
+		given(generateAccessTokenGateway.invoke(any(GenerateAccessTokenGateway.GenerateAccessTokenRequest.class))).willReturn(response);
+
+		// when
+		final GenerateAccessTokenPort.Command command = GenerateAccessTokenPort.Command.builder()
+			.memberId(String.valueOf(1L))
+			.deviceId(UUID.randomUUID().toString())
+			.build();
+		final GenerateAccessTokenPort.Result result = generateAccessTokenPortAdapter.invoke(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result).usingRecursiveComparison().isEqualTo(response);
+		verify(generateAccessTokenGateway, times(1)).invoke(any(GenerateAccessTokenGateway.GenerateAccessTokenRequest.class));
+	}
+
+}


### PR DESCRIPTION
## 🍋 개요
<!--
ex) Issue: Resolve #3
이슈 번호 앞에 Resolve를 붙이면, merge 시 자동으로 issue도 close됩니다.
-->
-  📌 Issue: Resolve #48 

## 🍊 변경 사항
- Access Token 재발급 API를 개발했어요.
- 로그인 API request body에 deviceId를 추가했어요.
    - memberId와 deviceId에 따라 Access/Refresh Token을 발급하기로 변경되었어요.
- Access/Refresh Token을 auth module에서 생성하도록 로직을 변경하였어요.

## 🥨 참고 사항


## 🍏 체크리스트
- [x] 변경된 파일마다 코드 정렬(`CTRL` + `ALT` + `L`)은 완료하였나요?
- [x] 설계된 내용대로 `구현`을 모두 완료하였나요?
- [x] 변경 사항에 대한 `Test Code`는 모두 작성하였나요?
- [x] `Commit Message`는 충분히 자세하게 작성되었나요?
- [x] `Assignees`, `Label`은 적용하였나요?