### PR TITLE
일반 로그인 API에 deviceId 발급 로직 및 devices 테이블 추가

### DIFF
--- a/sql/titi.sql
+++ b/sql/titi.sql
@@ -42,6 +42,18 @@ CREATE TRIGGER generate_hashcode
     FOR EACH ROW
     SET NEW.hashcode = generate_unique_hash_code();
 
+CREATE TABLE IF NOT EXISTS devices
+(
+    uuid             BINARY(16)  NOT NULL,
+    member_id        BIGINT      NOT NULL COMMENT '회원 PK',
+    device_type      VARCHAR(255) COMMENT '기기 유형',
+    last_accessed_at DATETIME(6) NOT NULL COMMENT '최근 접속 일시',
+    created_at       DATETIME(6) NOT NULL COMMENT '생성 일시',
+    updated_at       DATETIME(6) NOT NULL COMMENT '수정 일시',
+    PRIMARY KEY (uuid),
+    CONSTRAINT fk_devices_member_id FOREIGN KEY (member_id) REFERENCES members (id)
+) COMMENT '기기';
+
 CREATE TABLE IF NOT EXISTS oauth2_infos
 (
     id                   BIGINT AUTO_INCREMENT,

--- a/src/main/java/com/titi/titi_common_lib/constant/Constants.java
+++ b/src/main/java/com/titi/titi_common_lib/constant/Constants.java
@@ -11,7 +11,7 @@ public final class Constants {
 	public static final String DOT = ".";
 	public static final String UNDERSCORE = "_";
 
-
+	public static final int EOS = -1;
 	public static final int MILLI_SECONDS = 1;
 	public static final int SECONDS = 1;
 }

--- a/src/main/java/com/titi/titi_common_lib/util/HttpRequestHeaderParser.java
+++ b/src/main/java/com/titi/titi_common_lib/util/HttpRequestHeaderParser.java
@@ -1,0 +1,50 @@
+package com.titi.titi_common_lib.util;
+
+import static com.titi.titi_common_lib.constant.Constants.*;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class HttpRequestHeaderParser {
+
+	/**
+	 * The <b>User-Agent</b> request header is a characteristic string that lets servers and network peers identify the application,
+	 * operating system, vendor, and/or version of the requesting user agent.
+	 * <br/><br/>
+	 * <b>Syntax</b> <br/>
+	 * User-Agent: product / product-version comment <br/>
+	 * Common format for web browsers: <br/>
+	 * User-Agent: Mozilla/5.0 (system-information) platform (platform-details) extensions
+	 * <br/><br/>
+	 * @return system-information
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#field.user-agent">RFC-9110#field.user-agent</a>
+	 * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent">MDN Web Docs User-Agent</a>
+	 */
+	public static String parseSystemInformationFromUserAgent(@NonNull String userAgent) {
+		int firstSpaceIndex = userAgent.indexOf(' ');
+		if (firstSpaceIndex != EOS) {
+			return parseParenthesis(userAgent, firstSpaceIndex);
+		}
+		return failParseUserAgent(userAgent);
+	}
+
+	private static String parseParenthesis(String userAgent, int firstSpaceIndex) {
+		final String substringAfterSpace = userAgent.substring(firstSpaceIndex + 1);
+		final int openingParenthesisIndex = substringAfterSpace.indexOf('(');
+		final int closingParenthesisIndex = substringAfterSpace.indexOf(')');
+		if (openingParenthesisIndex != EOS && closingParenthesisIndex != EOS) {
+			return substringAfterSpace.substring(openingParenthesisIndex + 1, closingParenthesisIndex);
+		}
+		return failParseUserAgent(userAgent);
+	}
+
+	private static String failParseUserAgent(String userAgent) {
+		log.warn("Cannot parse system-information from User-Agent header: {}", userAgent);
+		return null;
+	}
+
+}

--- a/src/main/java/com/titi/titi_user/adapter/out/persistence/UpdateDeviceLastAccessPortAdapter.java
+++ b/src/main/java/com/titi/titi_user/adapter/out/persistence/UpdateDeviceLastAccessPortAdapter.java
@@ -1,0 +1,34 @@
+package com.titi.titi_user.adapter.out.persistence;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+import com.titi.titi_user.application.port.out.persistence.UpdateDeviceLastAccessPort;
+import com.titi.titi_user.data.jpa.entity.DeviceEntity;
+import com.titi.titi_user.data.jpa.entity.mapper.EntityMapper;
+import com.titi.titi_user.data.jpa.repository.DeviceEntityRepository;
+import com.titi.titi_user.domain.device.Device;
+
+@Component
+@RequiredArgsConstructor
+class UpdateDeviceLastAccessPortAdapter implements UpdateDeviceLastAccessPort {
+
+	private final DeviceEntityRepository deviceEntityRepository;
+
+	@Override
+	@Transactional
+	public Device invoke(Device device) {
+		if (device.deviceId() == null) {
+			return EntityMapper.INSTANCE.toDomain(this.deviceEntityRepository.save(EntityMapper.INSTANCE.toEntity(device)));
+		}
+		final DeviceEntity deviceEntity = this.deviceEntityRepository.findById(UUID.fromString(device.deviceId()))
+			.orElseGet(() -> this.deviceEntityRepository.save(EntityMapper.INSTANCE.toEntity(device)));
+		deviceEntity.updateLastAccessedAt(device.lastAccessedAt());
+		return EntityMapper.INSTANCE.toDomain(deviceEntity);
+	}
+
+}

--- a/src/main/java/com/titi/titi_user/application/port/in/LoginUseCase.java
+++ b/src/main/java/com/titi/titi_user/application/port/in/LoginUseCase.java
@@ -1,5 +1,7 @@
 package com.titi.titi_user.application.port.in;
 
+import org.springframework.lang.Nullable;
+
 import lombok.Builder;
 
 import com.titi.titi_user.domain.member.EncodedEncryptedPassword;
@@ -12,7 +14,8 @@ public interface LoginUseCase {
 	record Command(
 		String username,
 		EncodedEncryptedPassword encodedEncryptedPassword,
-		String deviceId
+		@Nullable String deviceId,
+		@Nullable String deviceType
 	) {
 
 	}
@@ -20,7 +23,8 @@ public interface LoginUseCase {
 	@Builder
 	record Result(
 		String accessToken,
-		String refreshToken
+		String refreshToken,
+		@Nullable String deviceId
 	) {
 
 	}

--- a/src/main/java/com/titi/titi_user/application/port/out/persistence/UpdateDeviceLastAccessPort.java
+++ b/src/main/java/com/titi/titi_user/application/port/out/persistence/UpdateDeviceLastAccessPort.java
@@ -1,0 +1,9 @@
+package com.titi.titi_user.application.port.out.persistence;
+
+import com.titi.titi_user.domain.device.Device;
+
+public interface UpdateDeviceLastAccessPort {
+
+	Device invoke(Device device);
+
+}

--- a/src/main/java/com/titi/titi_user/application/service/LoginService.java
+++ b/src/main/java/com/titi/titi_user/application/service/LoginService.java
@@ -1,16 +1,22 @@
 package com.titi.titi_user.application.service;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.titi.titi_user.application.port.in.LoginUseCase;
 import com.titi.titi_user.application.port.out.internal.GenerateAccessTokenPort;
 import com.titi.titi_user.application.port.out.persistence.FindMemberPort;
+import com.titi.titi_user.application.port.out.persistence.UpdateDeviceLastAccessPort;
 import com.titi.titi_user.common.TiTiUserBusinessCodes;
 import com.titi.titi_user.common.TiTiUserException;
+import com.titi.titi_user.domain.device.Device;
 import com.titi.titi_user.domain.member.Member;
 
 @Service
@@ -20,24 +26,39 @@ class LoginService implements LoginUseCase {
 	private final FindMemberPort findMemberPort;
 	private final PasswordEncoder passwordEncoder;
 	private final GenerateAccessTokenPort generateAccessTokenPort;
+	private final UpdateDeviceLastAccessPort updateDeviceLastAccessPort;
 	@Value("${crypto.secret-key}")
 	private String secretKey;
 
 	@Override
+	@Transactional
 	public Result invoke(Command command) {
 		final Member member = this.findMemberPort.invoke(Member.builder().username(command.username()).build())
 			.orElseThrow(() -> new TiTiUserException(TiTiUserBusinessCodes.LOGIN_FAILURE_MISMATCHED_MEMBER_INFORMATION));
 		final String rawPassword = command.encodedEncryptedPassword().getRawPassword(this.secretKey.getBytes());
 		this.validatePassword(rawPassword, member);
+
+		final String generatedDeviceId = command.deviceId() == null ? UUID.randomUUID().toString() : null;
+		final Device device = Device.builder()
+			.deviceId(command.deviceId() == null ? generatedDeviceId : command.deviceId())
+			.member(member)
+			.deviceType(command.deviceType())
+			.lastAccessedAt(LocalDateTime.now())
+			.build();
+
 		final GenerateAccessTokenPort.Result result = this.generateAccessTokenPort.invoke(
 			GenerateAccessTokenPort.Command.builder()
 				.memberId(String.valueOf(member.id()))
-				.deviceId(command.deviceId())
+				.deviceId(device.deviceId())
 				.build()
 		);
+
+		this.updateDeviceLastAccessPort.invoke(device);
+
 		return Result.builder()
 			.accessToken(result.accessToken())
 			.refreshToken(result.refreshToken())
+			.deviceId(generatedDeviceId)
 			.build();
 	}
 

--- a/src/main/java/com/titi/titi_user/data/jpa/entity/DeviceEntity.java
+++ b/src/main/java/com/titi/titi_user/data/jpa/entity/DeviceEntity.java
@@ -1,0 +1,46 @@
+package com.titi.titi_user.data.jpa.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.titi.infrastructure.persistence.jpa.entity.BaseEntity;
+
+@Entity(name = "devices")
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeviceEntity extends BaseEntity {
+
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.RANDOM)
+	private UUID uuid;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private MemberEntity member;
+
+	private String deviceType;
+
+	@Column(nullable = false)
+	private LocalDateTime lastAccessedAt;
+
+	public void updateLastAccessedAt(LocalDateTime lastAccessedAt) {
+		this.lastAccessedAt = lastAccessedAt;
+	}
+
+}

--- a/src/main/java/com/titi/titi_user/data/jpa/entity/mapper/EntityMapper.java
+++ b/src/main/java/com/titi/titi_user/data/jpa/entity/mapper/EntityMapper.java
@@ -1,9 +1,12 @@
 package com.titi.titi_user.data.jpa.entity.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
+import com.titi.titi_user.data.jpa.entity.DeviceEntity;
 import com.titi.titi_user.data.jpa.entity.MemberEntity;
+import com.titi.titi_user.domain.device.Device;
 import com.titi.titi_user.domain.member.Member;
 
 @Mapper
@@ -14,4 +17,10 @@ public interface EntityMapper {
 	MemberEntity toEntity(Member member);
 
 	Member toDomain(MemberEntity memberEntity);
+
+	@Mapping(source = "deviceId", target = "uuid")
+	DeviceEntity toEntity(Device device);
+
+	@Mapping(source = "uuid", target = "deviceId")
+	Device toDomain(DeviceEntity deviceEntity);
 }

--- a/src/main/java/com/titi/titi_user/data/jpa/repository/DeviceEntityRepository.java
+++ b/src/main/java/com/titi/titi_user/data/jpa/repository/DeviceEntityRepository.java
@@ -1,0 +1,11 @@
+package com.titi.titi_user.data.jpa.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.titi.titi_user.data.jpa.entity.DeviceEntity;
+
+public interface DeviceEntityRepository extends JpaRepository<DeviceEntity, UUID> {
+
+}

--- a/src/main/java/com/titi/titi_user/domain/device/Device.java
+++ b/src/main/java/com/titi/titi_user/domain/device/Device.java
@@ -1,0 +1,17 @@
+package com.titi.titi_user.domain.device;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+import com.titi.titi_user.domain.member.Member;
+
+@Builder(toBuilder = true)
+public record Device(
+	String deviceId,
+	Member member,
+	String deviceType,
+	LocalDateTime lastAccessedAt
+) {
+
+}

--- a/src/test/java/com/titi/titi_common_lib/util/HttpRequestHeaderParserTest.java
+++ b/src/test/java/com/titi/titi_common_lib/util/HttpRequestHeaderParserTest.java
@@ -1,0 +1,40 @@
+package com.titi.titi_common_lib.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class HttpRequestHeaderParserTest {
+
+	@Nested
+	class ParseSystemInformationFromUserAgent {
+
+		@Test
+		void successfulScenario() {
+			// given
+			final String userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1";
+
+			// when
+			final String systemInformation = HttpRequestHeaderParser.parseSystemInformationFromUserAgent(userAgent);
+
+			// then
+			assertThat(systemInformation).isNotNull();
+			assertThat(systemInformation).isEqualTo("iPhone; CPU iPhone OS 13_5_1 like Mac OS X");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = {"Mozilla/5.0", "Mozilla/4.0 look-alike"})
+		void failureScenario(String userAgent) {
+			// when
+			final String systemInformation = HttpRequestHeaderParser.parseSystemInformationFromUserAgent(userAgent);
+
+			// then
+			assertThat(systemInformation).isNull();
+		}
+
+	}
+
+}

--- a/src/test/java/com/titi/titi_user/adapter/in/web/api/LoginControllerTest.java
+++ b/src/test/java/com/titi/titi_user/adapter/in/web/api/LoginControllerTest.java
@@ -5,8 +5,6 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.UUID;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -35,12 +33,13 @@ class LoginControllerTest {
 		return LoginRequestBody.builder()
 			.username("test@gmail.com")
 			.encodedEncryptedPassword("encodedEncryptedPassword")
-			.deviceId(UUID.randomUUID().toString())
+			.deviceId("550e8400-e29b-41d4-a716-446655440000")
 			.build();
 	}
 
 	private ResultActions mockRegisterMember(LoginRequestBody requestBody) throws Exception {
 		return mockMvc.perform(post("/api/user/members/login")
+			.header("User-Agent", "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1")
 			.content(JacksonHelper.toJson(requestBody))
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON)
@@ -55,6 +54,7 @@ class LoginControllerTest {
 			LoginUseCase.Result.builder()
 				.accessToken("accessToken")
 				.refreshToken("refreshToken")
+				.deviceId("550e8400-e29b-41d4-a716-446655440000")
 				.build()
 		);
 
@@ -66,7 +66,8 @@ class LoginControllerTest {
 			.andExpect(jsonPath("$.code").value(TiTiUserBusinessCodes.LOGIN_SUCCESS.getCode()))
 			.andExpect(jsonPath("$.message").value(TiTiUserBusinessCodes.LOGIN_SUCCESS.getMessage()))
 			.andExpect(jsonPath("$.access_token").isNotEmpty())
-			.andExpect(jsonPath("$.refresh_token").isNotEmpty());
+			.andExpect(jsonPath("$.refresh_token").isNotEmpty())
+			.andExpect(jsonPath("$.device_id").isNotEmpty());
 		verify(loginUseCase, times(1)).invoke(any(LoginUseCase.Command.class));
 	}
 

--- a/src/test/java/com/titi/titi_user/adapter/out/persistence/UpdateDeviceLastAccessPortAdapterTest.java
+++ b/src/test/java/com/titi/titi_user/adapter/out/persistence/UpdateDeviceLastAccessPortAdapterTest.java
@@ -1,0 +1,112 @@
+package com.titi.titi_user.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.titi.titi_user.data.jpa.entity.DeviceEntity;
+import com.titi.titi_user.data.jpa.repository.DeviceEntityRepository;
+import com.titi.titi_user.domain.device.Device;
+import com.titi.titi_user.domain.member.Member;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateDeviceLastAccessPortAdapterTest {
+
+	@Mock
+	private DeviceEntityRepository deviceEntityRepository;
+
+	@InjectMocks
+	private UpdateDeviceLastAccessPortAdapter updateDeviceLastAccessPortAdapter;
+
+	@Test
+	void whenDeviceIdIsNullThenCreateDeviceEntity() {
+		// given
+		final DeviceEntity mockDeviceEntity = mock(DeviceEntity.class);
+		final LocalDateTime now = LocalDateTime.now();
+		final UUID uuid = UUID.randomUUID();
+		given(mockDeviceEntity.getUuid()).willReturn(uuid);
+		given(mockDeviceEntity.getLastAccessedAt()).willReturn(now);
+		given(deviceEntityRepository.save(any(DeviceEntity.class))).willReturn(mockDeviceEntity);
+
+		// when
+		final Device device = updateDeviceLastAccessPortAdapter.invoke(
+			Device.builder()
+				.deviceId(null)
+				.member(mock(Member.class))
+				.lastAccessedAt(now)
+				.build()
+		);
+
+		// then
+		assertThat(device).isNotNull();
+		assertThat(device.deviceId()).isEqualTo(uuid.toString());
+		assertThat(device.lastAccessedAt()).isEqualTo(now);
+		verify(deviceEntityRepository, never()).findById(any(UUID.class));
+		verify(deviceEntityRepository, times(1)).save(any(DeviceEntity.class));
+	}
+
+	@Test
+	void whenDeviceIdIsNotInDbThenCreateDeviceEntity() {
+		// given
+		final DeviceEntity mockDeviceEntity = mock(DeviceEntity.class);
+		final LocalDateTime now = LocalDateTime.now();
+		final UUID uuid = UUID.randomUUID();
+		given(mockDeviceEntity.getUuid()).willReturn(uuid);
+		given(mockDeviceEntity.getLastAccessedAt()).willReturn(now);
+		given(deviceEntityRepository.findById(any(UUID.class))).willReturn(Optional.empty());
+		given(deviceEntityRepository.save(any(DeviceEntity.class))).willReturn(mockDeviceEntity);
+
+		// when
+		final Device device = updateDeviceLastAccessPortAdapter.invoke(
+			Device.builder()
+				.deviceId(uuid.toString())
+				.member(mock(Member.class))
+				.lastAccessedAt(now)
+				.build()
+		);
+
+		// then
+		assertThat(device).isNotNull();
+		assertThat(device.deviceId()).isEqualTo(uuid.toString());
+		assertThat(device.lastAccessedAt()).isEqualTo(now);
+		verify(deviceEntityRepository, times(1)).save(any(DeviceEntity.class));
+		verify(deviceEntityRepository, times(1)).findById(any(UUID.class));
+	}
+
+	@Test
+	void whenDeviceIdIsInDbThenUpdateLastAccessedAt() {
+		// given
+		final DeviceEntity mockDeviceEntity = mock(DeviceEntity.class);
+		final UUID uuid = UUID.randomUUID();
+		final LocalDateTime now = LocalDateTime.now();
+		given(mockDeviceEntity.getUuid()).willReturn(uuid);
+		given(mockDeviceEntity.getLastAccessedAt()).willReturn(now);
+		given(deviceEntityRepository.findById(any(UUID.class))).willReturn(Optional.of(mockDeviceEntity));
+
+		// when
+		final Device device = updateDeviceLastAccessPortAdapter.invoke(
+			Device.builder()
+				.deviceId(uuid.toString())
+				.member(mock(Member.class))
+				.lastAccessedAt(now)
+				.build()
+		);
+
+		// then
+		assertThat(device).isNotNull();
+		assertThat(device.deviceId()).isEqualTo(uuid.toString());
+		assertThat(device.lastAccessedAt()).isEqualTo(now);
+		verify(deviceEntityRepository, never()).save(any(DeviceEntity.class));
+		verify(deviceEntityRepository, times(1)).findById(any(UUID.class));
+	}
+
+}

--- a/src/test/java/com/titi/titi_user/application/service/LoginServiceTest.java
+++ b/src/test/java/com/titi/titi_user/application/service/LoginServiceTest.java
@@ -21,7 +21,9 @@ import com.titi.titi_crypto_lib.util.AESUtils;
 import com.titi.titi_user.application.port.in.LoginUseCase;
 import com.titi.titi_user.application.port.out.internal.GenerateAccessTokenPort;
 import com.titi.titi_user.application.port.out.persistence.FindMemberPort;
+import com.titi.titi_user.application.port.out.persistence.UpdateDeviceLastAccessPort;
 import com.titi.titi_user.common.TiTiUserException;
+import com.titi.titi_user.domain.device.Device;
 import com.titi.titi_user.domain.member.EncodedEncryptedPassword;
 import com.titi.titi_user.domain.member.Member;
 
@@ -46,6 +48,9 @@ class LoginServiceTest {
 	@Mock
 	private FindMemberPort findMemberPort;
 
+	@Mock
+	private UpdateDeviceLastAccessPort updateDeviceLastAccessPort;
+
 	@InjectMocks
 	private LoginService loginService;
 
@@ -64,6 +69,7 @@ class LoginServiceTest {
 		given(passwordEncoder.matches(RAW_PASSWORD, BCRYPTED_PASSWORD)).willReturn(true);
 		given(generateAccessTokenPort.invoke(any(GenerateAccessTokenPort.Command.class)))
 			.willReturn(GenerateAccessTokenPort.Result.builder().accessToken(JWT).refreshToken(JWT).build());
+		given(updateDeviceLastAccessPort.invoke(any(Device.class))).willReturn(mock(Device.class));
 
 		// when
 		final LoginUseCase.Result result = loginService.invoke(

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,8 +18,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: ${TITI_SMTP_GMAIL_TEST_USERNAME}
-    password: ${TITI_SMTP_GMAIL_TEST_PASSWORD}
+    username: ${TITI_TEST_SMTP_GMAIL_USERNAME}
+    password: ${TITI_TEST_SMTP_GMAIL_PASSWORD}
     properties:
       mail:
         smtp:


### PR DESCRIPTION
## 🍋 개요
<!--
ex) Issue: Resolve #3
이슈 번호 앞에 Resolve를 붙이면, merge 시 자동으로 issue도 close됩니다.
-->
-  📌 Issue: Resolve #73 

## 🍊 변경 사항
- devices 테이블을 추가했어요. 관련 Entity, Repository를 추가하고, sql 파일에도 반영하였어요.
    - hibernate 6 버전부터 사용가능한 `@UuidGenerator`를 적용하여 PK를 `BINARY(16)` 형식으로 지정하였어요.
    - UUID는 [IETF RFC 4122 version 4](https://datatracker.ietf.org/doc/html/rfc4122#section-4.1.3) 기반으로 생성해요.
    > 관련 예제는 이 [포스팅](https://thorben-janssen.com/generate-uuids-primary-keys-hibernate/#generating-uuids-using-jpa-31-)을 참고하면 좋아요.
- 일반 로그인 API 비즈니스 로직에 최근 접속일을 업데이트하는 로직을 추가했어요.
    - User-Agent request header를 추가하여 어떤 종류의 기기인지 파악할 수 있게 로직을 추가하였어요.
    - User-Agent를 parsing하는 `HttpRequestHeaderParser` 클래스를 추가하였어요.
    - deviceId request body를 추가하였고, deviceId가 null이거나, DB에 존재하지 않는 deviceId인 경우, 새롭게 device entity를 생성하여 deviceId를 발급하는 로직을 추가하였어요.

## 🥨 참고 사항
아래 두 가지 작업도 진행해야 해요. 별도 issue로 등록하여 개발할 예정이에요.
- Access Token 재발급 API에도 device별 최근 접속 일시 update 로직을 추가해요. 해당 API의 domain을 user domain으로 변경하여 재설계해요.
- 최근 1년간 로그인하지 않은 deviceId가 존재한다면 제거하는 기능은 다른 issue로 등록하여 개발해요.

## 🍏 체크리스트
- [x] 변경된 파일마다 코드 정렬(`CTRL` + `ALT` + `L`)은 완료하였나요?
- [x] 설계된 내용대로 `구현`을 모두 완료하였나요?
- [x] 변경 사항에 대한 `Test Code`는 모두 작성하였나요?
- [x] `Commit Message`는 충분히 자세하게 작성되었나요?
- [x] `Assignees`, `Label`은 적용하였나요?